### PR TITLE
[Fix] Navbar - center social icons in a tags

### DIFF
--- a/src/components/NavBar/NavBar.module.scss
+++ b/src/components/NavBar/NavBar.module.scss
@@ -36,6 +36,9 @@
   width: 20px;
   margin: 0px 10px;
   @include variables.imageWrapper;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .navbarLogoImg {
@@ -68,7 +71,6 @@
 }
 
 .navbar a:hover {
-  // color: var(--grayscale-01-400);
   opacity: 50%;
 }
 


### PR DESCRIPTION
before
![image](https://github.com/HyperPlay-Gaming/hyperplay-ui/assets/27568879/a4447fe3-cac3-4ed4-8e2a-37a5f52aa023)


after
![image](https://github.com/HyperPlay-Gaming/hyperplay-ui/assets/27568879/a079a9a2-246c-471f-acb6-f7c42c594574)
