### PR TITLE
chore: Update the version of package to v0.1.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "license": "BUSL-1.1",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This PR is simple, we've just updated the package to v0.1.29 as before there was a version that was conflicting 🦺 

I think one reviewer should be enough for this, current package version << https://www.npmjs.com/package/@hyperplay/ui

