### PR TITLE
[Design System] Import hp design system after mantine

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -2,8 +2,6 @@ import React from 'react'
 import 'react-loading-skeleton/dist/skeleton.css'
 
 import HyperPlayDesignProvider from '../src/components/HyperPlayDesignProvider'
-import '../src/fonts.css'
-import '../src/index.scss'
 
 export const parameters = {
   backgrounds: {

--- a/src/components/HyperPlayDesignProvider/index.tsx
+++ b/src/components/HyperPlayDesignProvider/index.tsx
@@ -3,6 +3,10 @@ import React from 'react'
 import { MantineProvider, MantineProviderProps } from '@mantine/core'
 import '@mantine/core/styles.css'
 
+// import HyperPlay styles after mantine to override their defaults with our design system
+import '../../../src/fonts.css'
+import '../../../src/index.scss'
+
 export type HyperPlayDesignProviderProps = MantineProviderProps & {
   children: React.ReactNode
 }

--- a/src/styles/designSystem/_colors.scss
+++ b/src/styles/designSystem/_colors.scss
@@ -206,6 +206,10 @@
   @include colorSystem;
 }
 
+body {
+  color: var(--color-neutral-100);
+}
+
 .color-neutral-100 {
   color: var(--color-neutral-100);
 }


### PR DESCRIPTION
# Summary
By importing HyperPlay's design system after mantine's stylesheets, we can override their values

Overrides the body color value 