### PR TITLE
[Valist Migration] Export get youtube embed url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,5 +74,6 @@ export {
 export {
   default as Gallery,
   type GalleryProps,
-  type Asset
+  type Asset,
+  getYouTubeEmbedURL
 } from './components/Gallery'


### PR DESCRIPTION
# Summary

HyperPlay dev portal actually uses this function, so adding it to the index export