### PR TITLE
[Fix] Native platform input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "license": "UNLICENSED",
   "scripts": {
     "dev": "vite",

--- a/src/components/NativePlatformInput/NativePlatformInput.stories.tsx
+++ b/src/components/NativePlatformInput/NativePlatformInput.stories.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { Arch } from '@/common/types'
@@ -31,5 +33,16 @@ export const Default: Story = {
 }
 
 export const Mac: Story = {
-  args: { ...props, platformName: 'darwin', fileNameArm64: undefined }
+  args: { ...props, platformName: 'darwin', fileNameArm64: undefined },
+  render: (args) => {
+    const [file, setFile] = useState<string>('')
+    return (
+      <NativePlatformInput
+        {...args}
+        updateFile={(file) => setFile(file.name)}
+        clearFile={() => setFile('')}
+        fileNameAmd64={file}
+      ></NativePlatformInput>
+    )
+  }
 }

--- a/src/components/NativePlatformInput/components/PlatformUpload/index.tsx
+++ b/src/components/NativePlatformInput/components/PlatformUpload/index.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps, useRef } from 'react'
+import React, { HTMLProps } from 'react'
 
 import { Collapse, FileButton as FButton, Flex, Text } from '@mantine/core'
 import { IconFile, IconTrash } from '@tabler/icons-react'
@@ -38,10 +38,7 @@ export default function PlatformUpload({
   className,
   ...props
 }: PlatformUploadProps) {
-  const resetRef = useRef<() => void>(null)
-
   function onTrashClick() {
-    resetRef.current?.()
     onRemoveUpload()
   }
 
@@ -57,11 +54,7 @@ export default function PlatformUpload({
     )
   } else {
     uploadActionRow = (
-      <FButton
-        resetRef={resetRef}
-        onChange={onExePathChanged}
-        accept="application/zip"
-      >
+      <FButton onChange={onExePathChanged} accept="application/zip">
         {(props) => (
           <Button type="secondary" htmlType="button" {...props}>
             {i18n.chooseFile}


### PR DESCRIPTION
reset ref references the null FButton since it is not in the DOM and it throws, never calling `onRemoveUpload()` and preventing the user from removing the file they uploaded