### PR TITLE
[Fix] h1 overflow

### DIFF
--- a/src/styles/designSystem/_typography.scss
+++ b/src/styles/designSystem/_typography.scss
@@ -193,6 +193,11 @@ $h1FontSize: --text-9xl;
   font-weight: var(--bold);
   line-height: calc(var($h1FontSize) * 76 / 67);
   letter-spacing: -1%;
+  /** 
+   * Letter height is greater than line-height so the letters overflow.
+   * This can cause scrolling in containers that have plenty of room for content.
+   */
+  overflow: hidden;
 }
 
 h1 {


### PR DESCRIPTION
# Summary

```
/** 
   * Letter height is greater than line-height so the letters overflow.
   * This can cause scrolling in containers that have plenty of room for content.
   */
```

# Example
without this code
![image](https://github.com/HyperPlay-Gaming/hyperplay-ui/assets/27568879/0b753e04-1c7e-4b55-ac2b-b6f0d50c8253)

with this code
![image](https://github.com/HyperPlay-Gaming/hyperplay-ui/assets/27568879/51e2cef1-a948-4a09-8cbc-889fd83a1a4d)

