### PR TITLE
feat(quest-table): add support for string amounts and balances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.2.38",
+  "version": "1.2.39",
   "license": "UNLICENSED",
   "scripts": {
     "dev": "vite",

--- a/src/components/QuestsTable/QuestsTable.stories.tsx
+++ b/src/components/QuestsTable/QuestsTable.stories.tsx
@@ -75,3 +75,28 @@ const props: QuestsTableProps = {
 export const Default: Story = {
   args: { ...props }
 }
+
+export const EmptyQuests: Story = {
+  args: {
+    ...props,
+    quests: [
+      {
+        name: 'A quest',
+        rewards: [
+          {
+            amountPerPlayer: '-',
+            symbol: '',
+            balance: '-'
+          }
+        ],
+        type: 'Reputation',
+        status: 'DRAFT',
+        onClick: () => console.log('a quest clicked'),
+        claims: '-',
+        /* eslint-disable-next-line */
+        linkComponent: (props: any) => <a {...props} />,
+        linkProps: { href: 'https://hyperplay.xyz' }
+      }
+    ]
+  }
+}

--- a/src/components/QuestsTable/index.tsx
+++ b/src/components/QuestsTable/index.tsx
@@ -8,9 +8,9 @@ import Button from '../Button'
 import styles from './QuestsTable.module.scss'
 
 export interface RewardSimple {
-  amountPerPlayer: number
+  amountPerPlayer: number | string
   symbol: string
-  balance: number
+  balance: number | string
 }
 
 export type statusType = 'DRAFT' | 'ACTIVE'
@@ -48,7 +48,7 @@ export interface Quest {
   rewards: RewardSimple[]
   status: statusType
   onClick?: () => void
-  claims: number
+  claims: number | string
   id?: string | number
   /* eslint-disable-next-line */
   linkComponent?: any


### PR DESCRIPTION
this will give us a bit more flexibility on what we show in the table, we can now set empty strings or values like `-` instead of forcing us to have a number.