### PR TITLE
feat(quest): add support for reward contract context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.2.44",
+  "version": "1.2.45",
   "license": "UNLICENSED",
   "scripts": {
     "dev": "vite",

--- a/src/components/NoDeployedRewardContract/NoDeployedRewardContract.module.scss
+++ b/src/components/NoDeployedRewardContract/NoDeployedRewardContract.module.scss
@@ -28,3 +28,18 @@
 .text {
   margin: 0
 }
+
+.title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3xs);
+}
+
+.tooltip {
+  background: var(--color-neutral-200);
+  color: var(--color-neutral-900);
+}
+
+.arrow {
+  background: var(--color-neutral-200);
+}

--- a/src/components/NoDeployedRewardContract/NoDeployedRewardContract.module.scss
+++ b/src/components/NoDeployedRewardContract/NoDeployedRewardContract.module.scss
@@ -9,7 +9,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  background: var(--color-neutral-900);
+  background: var(--color-neutral-700);
   padding: var(--space-md);
   gap: var(--space-md);
   border-radius: var(--space-xs-fixed);

--- a/src/components/NoDeployedRewardContract/NoDeployedRewardContract.module.scss
+++ b/src/components/NoDeployedRewardContract/NoDeployedRewardContract.module.scss
@@ -9,10 +9,10 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  background: #13141A;
-  padding: 16px;
-  gap: var(--Spacing-2, 16px);
-  border-radius: 8px;
+  background: #13141a;
+  padding: var(--space-md);
+  gap: var(--space-md);
+  border-radius: var(--space-xs-fixed);
 }
 
 .button {
@@ -22,11 +22,11 @@
   background: var(--color-neutral-600);
   color: var(--color-neutral-400);
   font-size: var(--text-sm);
-  padding: 4px var(--spacing-Spacer-0, 0px);
+  padding: var(--space-3xs) 0;
 }
 
 .text {
-  margin: 0
+  margin: 0;
 }
 
 .title {

--- a/src/components/NoDeployedRewardContract/NoDeployedRewardContract.module.scss
+++ b/src/components/NoDeployedRewardContract/NoDeployedRewardContract.module.scss
@@ -1,0 +1,30 @@
+@use '../../styles/utilities/inputs';
+
+.root {
+  display: flex;
+  flex-direction: column;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  background: #13141A;
+  padding: 16px;
+  gap: var(--Spacing-2, 16px);
+  border-radius: 8px;
+}
+
+.button {
+  width: 100%;
+  align-items: center;
+  border-radius: var(--space-xs);
+  background: var(--color-neutral-600);
+  color: var(--color-neutral-400);
+  font-size: var(--text-sm);
+  padding: 4px var(--spacing-Spacer-0, 0px);
+}
+
+.text {
+  margin: 0
+}

--- a/src/components/NoDeployedRewardContract/NoDeployedRewardContract.module.scss
+++ b/src/components/NoDeployedRewardContract/NoDeployedRewardContract.module.scss
@@ -9,7 +9,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  background: #13141a;
+  background: var(--color-neutral-900);
   padding: var(--space-md);
   gap: var(--space-md);
   border-radius: var(--space-xs-fixed);

--- a/src/components/NoDeployedRewardContract/NoDeployedRewardContract.stories.tsx
+++ b/src/components/NoDeployedRewardContract/NoDeployedRewardContract.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import NoDeployedRewardContract from './index'
+
+const meta: Meta<typeof NoDeployedRewardContract> = {
+  title: 'quests/NoDeployedRewardContract',
+  component: NoDeployedRewardContract,
+  args: {
+    message:
+      'You currently don’t have an existing Reward Contract for ETH Mainnet Network. Please deploy a new Reward Contract.'
+  }
+}
+
+export default meta
+
+type Story = StoryObj<typeof NoDeployedRewardContract>
+
+export const Default: Story = {}

--- a/src/components/NoDeployedRewardContract/index.tsx
+++ b/src/components/NoDeployedRewardContract/index.tsx
@@ -1,0 +1,7 @@
+export function NoDeployedRewardContract() {
+  return (
+    <div>
+      <h1>NoDeployedRewardContract</h1>
+    </div>
+  )
+}

--- a/src/components/NoDeployedRewardContract/index.tsx
+++ b/src/components/NoDeployedRewardContract/index.tsx
@@ -1,3 +1,5 @@
+import { Tooltip } from '@mantine/core'
+import { IconInfoCircle } from '@tabler/icons-react'
 import cn from 'classnames'
 
 import styles from './NoDeployedRewardContract.module.scss'
@@ -8,6 +10,7 @@ interface Props {
   i18n?: {
     title: string
     button: string
+    tooltip: string
   }
 }
 
@@ -16,12 +19,30 @@ export function NoDeployedRewardContract({
   message,
   i18n = {
     title: 'Reward Contract',
-    button: 'Deploy Reward Contract'
+    button: 'Deploy Reward Contract',
+    tooltip:
+      'Reward Contracts are smart contracts that hold the balance of your Quest Rewards. See more in FAQ’s.'
   }
 }: Props) {
   return (
     <div className={styles.root}>
-      <span className={styles.label}>{i18n?.title}</span>
+      <div className={cn(styles.title, styles.label)}>
+        <span>{i18n?.title}</span>
+        <Tooltip
+          w={290}
+          multiline
+          classNames={{ tooltip: styles.tooltip, arrow: styles.arrow }}
+          label={i18n.tooltip}
+          position="bottom-start"
+          withArrow
+        >
+          <IconInfoCircle
+            color="var(--color-neutral-400)"
+            width={16}
+            height={16}
+          />
+        </Tooltip>
+      </div>
       <div className={styles.card}>
         <p className={cn('body-sm color-neutral-400', styles.text)}>
           {message}

--- a/src/components/NoDeployedRewardContract/index.tsx
+++ b/src/components/NoDeployedRewardContract/index.tsx
@@ -1,7 +1,37 @@
-export function NoDeployedRewardContract() {
+import cn from 'classnames'
+
+import styles from './NoDeployedRewardContract.module.scss'
+
+interface Props {
+  onDeployContract: () => void
+  message: string
+  i18n?: {
+    title: string
+    button: string
+  }
+}
+
+export function NoDeployedRewardContract({
+  onDeployContract,
+  message,
+  i18n = {
+    title: 'Reward Contract',
+    button: 'Deploy Reward Contract'
+  }
+}: Props) {
   return (
-    <div>
-      <h1>NoDeployedRewardContract</h1>
+    <div className={styles.root}>
+      <span className={styles.label}>{i18n?.title}</span>
+      <div className={styles.card}>
+        <p className={cn('body-sm color-neutral-400', styles.text)}>
+          {message}
+        </p>
+        <button onClick={onDeployContract} className={cn(styles.button)}>
+          {i18n.button}
+        </button>
+      </div>
     </div>
   )
 }
+
+export default NoDeployedRewardContract

--- a/src/components/RewardFormCard/RewardFormCard.stories.tsx
+++ b/src/components/RewardFormCard/RewardFormCard.stories.tsx
@@ -88,7 +88,7 @@ export const Erc20: Story = {
   args: {
     children: (
       <RewardERC20_721
-        tokenType="ERC20"
+        tokenType="ERC-20"
         rewardContractProps={{ rewardContract: defaultRewardContractProps }}
         tokenTypeInputProps={defaultTokenTypeInputProps}
         tokenContractAddressInputProps={defaultTokenContractAddressInputProps}
@@ -101,7 +101,7 @@ export const Erc721: Story = {
   args: {
     children: (
       <RewardERC20_721
-        tokenType="ERC721"
+        tokenType="ERC-721"
         rewardContractProps={{ rewardContract: defaultRewardContractProps }}
         tokenTypeInputProps={defaultTokenTypeInputProps}
         tokenContractAddressInputProps={defaultTokenContractAddressInputProps}
@@ -124,9 +124,9 @@ export const Erc1155: Story = {
 
 const rewardsDetailsSchema = z.object({
   reward_type: z.union([
-    z.literal('ERC721'),
-    z.literal('ERC1155'),
-    z.literal('ERC20')
+    z.literal('ERC-721'),
+    z.literal('ERC-1155'),
+    z.literal('ERC-20')
   ]),
   chain_id: z.string(),
   image: z.string().url(),
@@ -236,7 +236,7 @@ export const Controlled: Story = {
     }
 
     if (form.values.chain_id && contractAddress && formTokenType) {
-      if (formTokenType === 'ERC1155') {
+      if (formTokenType === 'ERC-1155') {
         children = (
           <RewardERC1155
             {...commonProps}

--- a/src/components/RewardFormCard/RewardFormCard.stories.tsx
+++ b/src/components/RewardFormCard/RewardFormCard.stories.tsx
@@ -19,7 +19,7 @@ const ethContractAddressRegex = /^0x[a-fA-F0-9]{40}$/g
 
 const defaultNetworkInputProps = {
   data: [
-    { value: '1', label: 'Ethereum' },
+    { value: '1', label: 'ETH Mainnet' },
     { value: '0x38', label: 'Binance Smart Chain' },
     { value: '0x89', label: 'Polygon' },
     { value: '0x4', label: 'Rinkeby' }
@@ -117,6 +117,9 @@ export const Erc1155: Story = {
         rewardContractProps={{ rewardContract: defaultRewardContractProps }}
         tokenTypeInputProps={defaultTokenTypeInputProps}
         tokenContractAddressInputProps={defaultTokenContractAddressInputProps}
+        tokenIdsInputProps={Array.from({ length: 1 }).map(() => ({
+          onRemoveClick: () => alert('removing id')
+        }))}
       />
     )
   }
@@ -139,6 +142,7 @@ const rewardsDetailsSchema = z.object({
   token_ids: z.array(
     z.object({
       amount_per_user: z.string(),
+      id: z.string(),
       name: z.string()
     })
   )
@@ -150,8 +154,12 @@ type TokenType = FormSchema['reward_type']
 export const Controlled: Story = {
   render: () => {
     const form = useForm<FormSchema>({
-      // @ts-expect-error: token_ids need to be initialized as an empty array
-      initialValues: { token_ids: [] },
+      initialValues: {
+        token_ids: [
+          // @ts-expect-error: amount_per_user, id, and name need to be initialized as undefined
+          { amount_per_user: undefined, id: undefined, name: undefined }
+        ]
+      },
       validate: zodResolver(rewardsDetailsSchema)
     })
 
@@ -242,6 +250,7 @@ export const Controlled: Story = {
             {...commonProps}
             addTokenId={() => form.insertListItem('token_ids', {})}
             tokenIdsInputProps={form.values.token_ids?.map((_, index) => ({
+              tokenIdInputProps: form.getInputProps(`token_ids.${index}.id`),
               tokenNameInputProps: form.getInputProps(
                 `token_ids.${index}.name`
               ),

--- a/src/components/RewardFormCard/RewardFormCard.stories.tsx
+++ b/src/components/RewardFormCard/RewardFormCard.stories.tsx
@@ -70,7 +70,10 @@ export const WithIcon: Story = {
 export const NoRewardContract: Story = {
   args: {
     children: (
-      <NoDeployedRewardContract message="You currently don’t have an existing Reward Contract for ETH Mainnet Network. Please deploy a new Reward Contract." />
+      <NoDeployedRewardContract
+        onDeployContract={() => alert('Deploy contract')}
+        message="You currently don’t have an existing Reward Contract for ETH Mainnet Network. Please deploy a new Reward Contract."
+      />
     )
   }
 }

--- a/src/components/RewardFormCard/RewardFormCard.stories.tsx
+++ b/src/components/RewardFormCard/RewardFormCard.stories.tsx
@@ -36,7 +36,7 @@ const defaultTokenContractAddressInputProps = {
 const defaultTokenTypeInputProps = {
   label: 'Reward Token Type',
   placeholder: 'Select a Reward Token Type',
-  data: ['ERC20', 'ERC721', 'ERC1155']
+  data: ['ERC-20', 'ERC-721', 'ERC-1155']
 }
 
 const defaultRewardContractProps = {

--- a/src/components/RewardFormCard/RewardFormCard.stories.tsx
+++ b/src/components/RewardFormCard/RewardFormCard.stories.tsx
@@ -8,6 +8,7 @@ import Button from '@/components/Button'
 import NoDeployedRewardContract from '@/components/NoDeployedRewardContract'
 
 import {
+  RewardCommonInputs,
   RewardCommonInputsProps,
   RewardERC20_721,
   RewardERC1155
@@ -36,6 +37,11 @@ const defaultTokenTypeInputProps = {
   label: 'Reward Token Type',
   placeholder: 'Select a Reward Token Type',
   data: ['ERC20', 'ERC721', 'ERC1155']
+}
+
+const defaultRewardContractProps = {
+  address: '0xC38329b34E939d3C9165D7301e8349Ec3036CB1c',
+  url: 'https://etherscan.io/address/0xC38329b34E939d3C9165D7301e8349Ec3036CB1c'
 }
 
 const meta: Meta<typeof RewardFormCard> = {
@@ -83,6 +89,7 @@ export const Erc20: Story = {
     children: (
       <RewardERC20_721
         tokenType="ERC20"
+        rewardContractProps={{ rewardContract: defaultRewardContractProps }}
         tokenTypeInputProps={defaultTokenTypeInputProps}
         tokenContractAddressInputProps={defaultTokenContractAddressInputProps}
       />
@@ -95,6 +102,7 @@ export const Erc721: Story = {
     children: (
       <RewardERC20_721
         tokenType="ERC721"
+        rewardContractProps={{ rewardContract: defaultRewardContractProps }}
         tokenTypeInputProps={defaultTokenTypeInputProps}
         tokenContractAddressInputProps={defaultTokenContractAddressInputProps}
       />
@@ -106,6 +114,7 @@ export const Erc1155: Story = {
   args: {
     children: (
       <RewardERC1155
+        rewardContractProps={{ rewardContract: defaultRewardContractProps }}
         tokenTypeInputProps={defaultTokenTypeInputProps}
         tokenContractAddressInputProps={defaultTokenContractAddressInputProps}
       />
@@ -198,36 +207,67 @@ export const Controlled: Story = {
       }
     }
 
+    if (contractAddress) {
+      commonProps.rewardContractProps = {
+        rewardContract: {
+          address: contractAddress,
+          url: `https://etherscan.io/address/${contractAddress}`
+        }
+      }
+    }
+
     let children = null
 
-    if (formTokenType === 'ERC1155') {
+    if (form.values.chain_id && !contractAddress) {
       children = (
-        <RewardERC1155
-          {...commonProps}
-          addTokenId={() => form.insertListItem('token_ids', {})}
-          tokenIdsInputProps={form.values.token_ids?.map((_, index) => ({
-            tokenNameInputProps: form.getInputProps(`token_ids.${index}.name`),
-            amountPerUserInputProps: form.getInputProps(
-              `token_ids.${index}.amount_per_user`
-            ),
-            onRemoveClick: () => {
-              if (form.values.token_ids?.length === 1) return
-              form.removeListItem('token_ids', index)
-            }
-          }))}
-          marketplaceUrlInputProps={form.getInputProps('marketplace_url')}
+        <NoDeployedRewardContract
+          onDeployContract={() => alert('Deploy contract')}
+          message={`You currently don’t have an existing Reward Contract for ${
+            defaultNetworkInputProps.data.find(
+              ({ value }) => value === form.values.chain_id
+            )?.label
+          } Network. Please deploy a new Reward Contract.`}
         />
       )
-    } else if (formTokenType) {
-      children = (
-        <RewardERC20_721
-          tokenType={formTokenType}
-          tokenNameInputProps={form.getInputProps('name')}
-          decimalsInputProps={form.getInputProps('decimals')}
-          amountPerUserInputProps={form.getInputProps('amount_per_user')}
-          marketplaceUrlInputProps={form.getInputProps('marketplace_url')}
-        />
-      )
+    }
+
+    if (form.values.chain_id && contractAddress && !formTokenType) {
+      children = <RewardCommonInputs {...commonProps} />
+    }
+
+    if (form.values.chain_id && contractAddress && formTokenType) {
+      if (formTokenType === 'ERC1155') {
+        children = (
+          <RewardERC1155
+            {...commonProps}
+            addTokenId={() => form.insertListItem('token_ids', {})}
+            tokenIdsInputProps={form.values.token_ids?.map((_, index) => ({
+              tokenNameInputProps: form.getInputProps(
+                `token_ids.${index}.name`
+              ),
+              amountPerUserInputProps: form.getInputProps(
+                `token_ids.${index}.amount_per_user`
+              ),
+              onRemoveClick: () => {
+                if (form.values.token_ids?.length === 1) return
+                form.removeListItem('token_ids', index)
+              }
+            }))}
+            marketplaceUrlInputProps={form.getInputProps('marketplace_url')}
+          />
+        )
+      } else {
+        children = (
+          <RewardERC20_721
+            {...commonProps}
+            tokenType={formTokenType}
+            tokenNameInputProps={form.getInputProps('name')}
+            decimalsInputProps={form.getInputProps('decimals')}
+            amountPerUserInputProps={form.getInputProps('amount_per_user')}
+            marketplaceUrlInputProps={form.getInputProps('marketplace_url')}
+          />
+        )
+      }
     }
 
     return (

--- a/src/components/RewardFormCard/RewardFormCard.stories.tsx
+++ b/src/components/RewardFormCard/RewardFormCard.stories.tsx
@@ -5,6 +5,7 @@ import { IconTrash } from '@tabler/icons-react'
 import { z } from 'zod'
 
 import Button from '@/components/Button'
+import NoDeployedRewardContract from '@/components/NoDeployedRewardContract'
 
 import {
   RewardCommonInputsProps,
@@ -63,6 +64,14 @@ export const Default: Story = {}
 export const WithIcon: Story = {
   args: {
     icon: <DeleteButton onClick={() => alert('Delete reward clicked')} />
+  }
+}
+
+export const NoRewardContract: Story = {
+  args: {
+    children: (
+      <NoDeployedRewardContract message="You currently don’t have an existing Reward Contract for ETH Mainnet Network. Please deploy a new Reward Contract." />
+    )
   }
 }
 
@@ -135,6 +144,16 @@ export const Controlled: Story = {
     })
 
     const formTokenType = form.values.reward_type
+
+    // only for testing purposes
+    const networksContracts = new Map(
+      defaultNetworkInputProps.data.map(({ value }, index) => [
+        value,
+        index % 2 === 0 ? '0xC38329b34E939d3C9165D7301e8349Ec3036CB1c' : null
+      ])
+    )
+
+    const contractAddress = networksContracts.get(form.values.chain_id)
 
     const onFileChange = (file: File | null) => {
       if (!file) return

--- a/src/components/RewardFormCard/index.tsx
+++ b/src/components/RewardFormCard/index.tsx
@@ -4,19 +4,12 @@ import {
   ContainerInteractive,
   ContainerInteractiveProps
 } from '@/components/ContainerInteractive'
-import RewardImageInput, {
-  RewardImageInputProps
-} from '@/components/RewardImageInput'
 import Select, { SelectProps } from '@/components/Select'
-import TextInput, { TextInputProps } from '@/components/TextInput'
 
 import styles from './RewardFormCard.module.scss'
 
 export interface RewardFormCardProps extends ContainerInteractiveProps {
   networkInputProps?: SelectProps
-  tokenContractAddressInputProps?: TextInputProps
-  tokenTypeInputProps?: SelectProps
-  rewardImageProps?: RewardImageInputProps
 }
 
 function RewardFormCard({ classNames, ...props }: RewardFormCardProps) {
@@ -30,24 +23,7 @@ function RewardFormCard({ classNames, ...props }: RewardFormCardProps) {
       {...props}
     >
       <Select {...props.networkInputProps} />
-      <div className={styles.split}>
-        <div>
-          <RewardImageInput label="Reward Image" {...props.rewardImageProps} />
-          <span className="text--sm color-neutral-400 text--semibold">
-            Requirements:
-          </span>
-          <ul className={cn('color-neutral-400', styles.requirementList)}>
-            <li>SVG, PNG, JPG</li>
-            <li>1:1 Ratio</li>
-            <li>Min: 48px</li>
-          </ul>
-        </div>
-        <div className={styles.inputs}>
-          <TextInput {...props.tokenContractAddressInputProps} />
-          <Select {...props.tokenTypeInputProps} />
-          {props.children}
-        </div>
-      </div>
+      {props.children}
     </ContainerInteractive>
   )
 }

--- a/src/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs/RewardCommonInputs.module.scss
+++ b/src/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs/RewardCommonInputs.module.scss
@@ -1,0 +1,18 @@
+.split {
+  display: flex;
+  gap: var(--space-md);
+}
+
+.requirementList {
+  font-size: var(--text-sm);
+  margin-block-start: var(--space-2xs);
+  margin-block-end: 0;
+  padding-inline-start: var(--space-lg);
+}
+
+.inputs {
+  flex: 1;
+  gap: var(--space-md);
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs/RewardCommonInputs.module.scss
+++ b/src/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs/RewardCommonInputs.module.scss
@@ -1,6 +1,5 @@
 @use '../../../../../../styles/utilities/inputs';
 
-
 .split {
   display: flex;
   gap: var(--space-md);

--- a/src/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs/RewardCommonInputs.module.scss
+++ b/src/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs/RewardCommonInputs.module.scss
@@ -1,3 +1,6 @@
+@use '../../../../../../styles/utilities/inputs';
+
+
 .split {
   display: flex;
   gap: var(--space-md);
@@ -15,4 +18,29 @@
   gap: var(--space-md);
   display: flex;
   flex-direction: column;
+}
+
+.tooltip {
+  background: var(--color-neutral-200);
+  color: var(--color-neutral-900);
+}
+
+.arrow {
+  background: var(--color-neutral-200);
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3xs);
+}
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2lg);
+}
+
+.link {
+  color: var(--color-primary-200) !important;
 }

--- a/src/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs/index.tsx
+++ b/src/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs/index.tsx
@@ -1,0 +1,42 @@
+import cn from 'classnames'
+
+import RewardImageInput, {
+  RewardImageInputProps
+} from '@/components/RewardImageInput'
+import Select, { SelectProps } from '@/components/Select'
+import TextInput, { TextInputProps } from '@/components/TextInput'
+
+import styles from './RewardCommonInputs.module.scss'
+
+export interface RewardCommonInputsProps {
+  networkInputProps?: SelectProps
+  tokenContractAddressInputProps?: TextInputProps
+  tokenTypeInputProps?: SelectProps
+  rewardImageProps?: RewardImageInputProps
+  children?: React.ReactNode
+}
+
+export function RewardCommonInputs(props: RewardCommonInputsProps) {
+  return (
+    <div className={styles.split}>
+      <div>
+        <RewardImageInput label="Reward Image" {...props.rewardImageProps} />
+        <span className="text--sm color-neutral-400 text--semibold">
+          Requirements:
+        </span>
+        <ul className={cn('color-neutral-400', styles.requirementList)}>
+          <li>SVG, PNG, JPG</li>
+          <li>1:1 Ratio</li>
+          <li>Min: 48px</li>
+        </ul>
+      </div>
+      <div className={styles.inputs}>
+        <TextInput {...props.tokenContractAddressInputProps} />
+        <Select {...props.tokenTypeInputProps} />
+        {props.children}
+      </div>
+    </div>
+  )
+}
+
+export default RewardCommonInputs

--- a/src/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs/index.tsx
+++ b/src/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs/index.tsx
@@ -1,3 +1,5 @@
+import { Tooltip } from '@mantine/core'
+import { IconInfoCircle } from '@tabler/icons-react'
 import cn from 'classnames'
 
 import RewardImageInput, {
@@ -8,32 +10,91 @@ import TextInput, { TextInputProps } from '@/components/TextInput'
 
 import styles from './RewardCommonInputs.module.scss'
 
+interface RewardContractProps {
+  rewardContract: { address: string; url: string }
+  i18n?: {
+    rewardContractLabel: string
+    tooltip: string
+  }
+}
+
+function RewardContract({
+  i18n = {
+    rewardContractLabel: 'Reward Contract',
+    tooltip:
+      'Reward Contracts are smart contracts that hold the balance of your Quest Rewards. See more in FAQ’s.'
+  },
+  rewardContract
+}: {
+  rewardContract: { address: string; url: string }
+  i18n?: {
+    rewardContractLabel: string
+    tooltip: string
+  }
+}) {
+  return (
+    <div>
+      <div className={cn(styles.title, styles.label)}>
+        <span>{i18n.rewardContractLabel}</span>
+        <Tooltip
+          w={290}
+          multiline
+          classNames={{ tooltip: styles.tooltip, arrow: styles.arrow }}
+          label={i18n.tooltip}
+          position="bottom-start"
+          withArrow
+        >
+          <IconInfoCircle
+            color="var(--color-neutral-400)"
+            width={16}
+            height={16}
+          />
+        </Tooltip>
+      </div>
+      <a
+        href={rewardContract.url}
+        target="_blank"
+        rel="noreferrer"
+        className={styles.link}
+      >
+        {rewardContract.address}
+      </a>
+    </div>
+  )
+}
+
 export interface RewardCommonInputsProps {
   networkInputProps?: SelectProps
   tokenContractAddressInputProps?: TextInputProps
   tokenTypeInputProps?: SelectProps
   rewardImageProps?: RewardImageInputProps
+  rewardContractProps?: RewardContractProps
   children?: React.ReactNode
 }
 
-export function RewardCommonInputs(props: RewardCommonInputsProps) {
+export function RewardCommonInputs({ ...props }: RewardCommonInputsProps) {
   return (
-    <div className={styles.split}>
-      <div>
-        <RewardImageInput label="Reward Image" {...props.rewardImageProps} />
-        <span className="text--sm color-neutral-400 text--semibold">
-          Requirements:
-        </span>
-        <ul className={cn('color-neutral-400', styles.requirementList)}>
-          <li>SVG, PNG, JPG</li>
-          <li>1:1 Ratio</li>
-          <li>Min: 48px</li>
-        </ul>
-      </div>
-      <div className={styles.inputs}>
-        <TextInput {...props.tokenContractAddressInputProps} />
-        <Select {...props.tokenTypeInputProps} />
-        {props.children}
+    <div className={styles.root}>
+      {props.rewardContractProps && (
+        <RewardContract {...props.rewardContractProps} />
+      )}
+      <div className={styles.split}>
+        <div>
+          <RewardImageInput label="Reward Image" {...props.rewardImageProps} />
+          <span className="text--sm color-neutral-400 text--semibold">
+            Requirements:
+          </span>
+          <ul className={cn('color-neutral-400', styles.requirementList)}>
+            <li>SVG, PNG, JPG</li>
+            <li>1:1 Ratio</li>
+            <li>Min: 48px</li>
+          </ul>
+        </div>
+        <div className={styles.inputs}>
+          <TextInput {...props.tokenContractAddressInputProps} />
+          <Select {...props.tokenTypeInputProps} />
+          {props.children}
+        </div>
       </div>
     </div>
   )

--- a/src/components/RewardsSummary/components/FormRewards/components/RewardERC1155/components/TokenIdRow/index.tsx
+++ b/src/components/RewardsSummary/components/FormRewards/components/RewardERC1155/components/TokenIdRow/index.tsx
@@ -17,6 +17,7 @@ export interface TokenIdRowProps extends TokenIdRowInputProps {
 
 export function TokenIdRow({
   tokenNameInputProps,
+  tokenIdInputProps,
   amountPerUserInputProps,
   onRemoveClick,
   i18n = DEFAULT_FORM_REWARDS_i18n
@@ -28,6 +29,11 @@ export function TokenIdRow({
           label={i18n.label.tokenName}
           placeholder={i18n.placeholder.tokenName}
           {...tokenNameInputProps}
+        />
+        <TextInput
+          label={i18n.label.tokenId}
+          placeholder={i18n.placeholder.tokenId}
+          {...tokenIdInputProps}
         />
         <NumberInput
           label={i18n.label.amountPerUser}

--- a/src/components/RewardsSummary/components/FormRewards/components/RewardERC1155/index.tsx
+++ b/src/components/RewardsSummary/components/FormRewards/components/RewardERC1155/index.tsx
@@ -5,6 +5,9 @@ import React from 'react'
 import { IconPlus } from '@tabler/icons-react'
 
 import Button from '@/components/Button'
+import RewardCommonInputs, {
+  RewardCommonInputsProps
+} from '@/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs'
 import TextInput, { TextInputProps } from '@/components/TextInput'
 
 import { DEFAULT_FORM_REWARDS_i18n, FormRewardsI18n } from '../..'
@@ -12,7 +15,7 @@ import { TokenIdRowInputProps } from '../../types'
 import { TokenIdRow } from './components/TokenIdRow'
 import styles from './index.module.scss'
 
-export interface RewardERC1155Props {
+export interface RewardERC1155Props extends RewardCommonInputsProps {
   marketplaceUrlInputProps?: TextInputProps
   tokenIdsInputProps?: TokenIdRowInputProps[]
   addTokenId?: () => void
@@ -23,13 +26,14 @@ export function RewardERC1155({
   marketplaceUrlInputProps,
   tokenIdsInputProps = [],
   addTokenId,
-  i18n = DEFAULT_FORM_REWARDS_i18n
+  i18n = DEFAULT_FORM_REWARDS_i18n,
+  ...commonInputsProps
 }: RewardERC1155Props) {
   const tokenIdRows = tokenIdsInputProps.map((inputs_i, index) => (
     <TokenIdRow key={index} i18n={i18n} {...inputs_i} />
   ))
   return (
-    <>
+    <RewardCommonInputs {...commonInputsProps}>
       <div>
         <div className={styles.tokenIdContainer}>
           {tokenIdRows}
@@ -52,6 +56,6 @@ export function RewardERC1155({
           {...marketplaceUrlInputProps}
         />
       </div>
-    </>
+    </RewardCommonInputs>
   )
 }

--- a/src/components/RewardsSummary/components/FormRewards/components/RewardERC20_721/index.tsx
+++ b/src/components/RewardsSummary/components/FormRewards/components/RewardERC20_721/index.tsx
@@ -15,7 +15,7 @@ export interface RewardERC20_721Props
   extends TokenRewardInput,
     RewardCommonInputsProps {
   decimalsInputProps?: NumberInputProps
-  tokenType: 'ERC20' | 'ERC721'
+  tokenType: 'ERC-20' | 'ERC-721'
   marketplaceUrlInputProps?: TextInputProps
   i18n?: FormRewardsI18n
 }
@@ -37,7 +37,7 @@ export function RewardERC20_721({
     />
   )
 
-  if (tokenType === 'ERC20') {
+  if (tokenType === 'ERC-20') {
     tokenInput = (
       <NumberInput
         label={i18n.label.decimals}
@@ -57,7 +57,7 @@ export function RewardERC20_721({
         />
         {tokenInput}
       </div>
-      {tokenType === 'ERC20' ? (
+      {tokenType === 'ERC-20' ? (
         <NumberInput
           label={i18n.label.amountPerUser}
           placeholder={i18n.placeholder.amountPerUser}

--- a/src/components/RewardsSummary/components/FormRewards/components/RewardERC20_721/index.tsx
+++ b/src/components/RewardsSummary/components/FormRewards/components/RewardERC20_721/index.tsx
@@ -3,13 +3,17 @@
 import React from 'react'
 
 import NumberInput, { NumberInputProps } from '@/components/NumberInput'
+import { RewardCommonInputsProps } from '@/components/RewardsSummary/components/FormRewards/components/RewardCommonInputs'
 import TextInput, { TextInputProps } from '@/components/TextInput'
+import { RewardCommonInputs } from '@/index'
 
 import { DEFAULT_FORM_REWARDS_i18n, FormRewardsI18n } from '../..'
 import { TokenRewardInput } from '../../types'
 import styles from './index.module.scss'
 
-export interface RewardERC20_721Props extends TokenRewardInput {
+export interface RewardERC20_721Props
+  extends TokenRewardInput,
+    RewardCommonInputsProps {
   decimalsInputProps?: NumberInputProps
   tokenType: 'ERC20' | 'ERC721'
   marketplaceUrlInputProps?: TextInputProps
@@ -22,7 +26,8 @@ export function RewardERC20_721({
   amountPerUserInputProps,
   marketplaceUrlInputProps,
   tokenType,
-  i18n = DEFAULT_FORM_REWARDS_i18n
+  i18n = DEFAULT_FORM_REWARDS_i18n,
+  ...commonInputsProps
 }: RewardERC20_721Props) {
   let tokenInput = (
     <TextInput
@@ -43,7 +48,7 @@ export function RewardERC20_721({
   }
 
   return (
-    <>
+    <RewardCommonInputs {...commonInputsProps}>
       <div className={styles.tokenContainer}>
         <TextInput
           label={i18n.label.tokenName}
@@ -59,6 +64,6 @@ export function RewardERC20_721({
           {...amountPerUserInputProps}
         />
       ) : null}
-    </>
+    </RewardCommonInputs>
   )
 }

--- a/src/components/RewardsSummary/components/FormRewards/index.tsx
+++ b/src/components/RewardsSummary/components/FormRewards/index.tsx
@@ -13,24 +13,26 @@ import { RewardERC1155 } from './components/RewardERC1155'
 import { TokenIdRowInputProps } from './types'
 
 export const DEFAULT_FORM_REWARDS_i18n: FormRewardsI18n = {
-  addTokenId: 'Add Token ID',
+  addTokenId: 'Add Token',
   placeholder: {
     rewardType: 'Reward Type',
     network: 'Network',
     contractAddress: 'Contract Address',
-    tokenName: 'Token',
-    marketplaceUrl: 'Marketplace URL',
+    tokenName: 'Ex: GOLD',
+    marketplaceUrl: 'https://',
     decimals: 'Decimals',
-    amountPerUser: 'Amount Per User'
+    amountPerUser: 'Amount Per User',
+    tokenId: 'Enter token ID'
   },
   label: {
     rewardType: 'Reward Type',
     network: 'Network',
     contractAddress: 'Contract Address',
-    tokenName: 'Token',
+    tokenName: 'Token Name',
     marketplaceUrl: 'Marketplace URL',
     decimals: 'Decimals',
-    amountPerUser: 'Amount Per User'
+    amountPerUser: 'Amount Per Player',
+    tokenId: 'Token ID'
   }
 }
 
@@ -44,6 +46,7 @@ export interface FormRewardsI18n {
     marketplaceUrl: string
     decimals: string
     amountPerUser: string
+    tokenId: string
   }
   label: {
     rewardType: string
@@ -53,6 +56,7 @@ export interface FormRewardsI18n {
     marketplaceUrl: string
     decimals: string
     amountPerUser: string
+    tokenId: string
   }
 }
 
@@ -86,10 +90,10 @@ export function FormRewards(props: FormRewardsProps) {
   let content = null
   if (selectedTokenType) {
     if (selectedTokenType.text === 'ERC721') {
-      content = <RewardERC20_721 tokenType="ERC721" {...props} />
-    } else if (selectedTokenType.text === 'ERC20') {
-      content = <RewardERC20_721 tokenType="ERC20" {...props} />
-    } else if (selectedTokenType.text === 'ERC1155') {
+      content = <RewardERC20_721 tokenType="ERC-721" {...props} />
+    } else if (selectedTokenType.text === 'ERC-20') {
+      content = <RewardERC20_721 tokenType="ERC-20" {...props} />
+    } else if (selectedTokenType.text === 'ERC-1155') {
       content = <RewardERC1155 {...props} />
     }
   }

--- a/src/components/RewardsSummary/components/FormRewards/types.ts
+++ b/src/components/RewardsSummary/components/FormRewards/types.ts
@@ -3,6 +3,7 @@ import { TextInputProps } from '@/components/TextInput'
 
 export interface TokenRewardInput {
   tokenNameInputProps?: TextInputProps
+  tokenIdInputProps?: TextInputProps
   amountPerUserInputProps?: NumberInputProps
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,3 +206,5 @@ export { default as RewardDepositTokenList } from './components/RewardDeposit/co
 
 export { default as RewardCommonInputs } from './components/RewardsSummary/components/FormRewards/components/RewardCommonInputs'
 export type { RewardCommonInputsProps } from './components/RewardsSummary/components/FormRewards/components/RewardCommonInputs'
+
+export { default as NoDeployedRewardContract } from './components/NoDeployedRewardContract'

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,3 +203,6 @@ export type {
 } from './components/RewardDeposit'
 
 export { default as RewardDepositTokenList } from './components/RewardDeposit/components/RewardDepositTokensList'
+
+export { default as RewardCommonInputs } from './components/RewardsSummary/components/FormRewards/components/RewardCommonInputs'
+export type { RewardCommonInputsProps } from './components/RewardsSummary/components/FormRewards/components/RewardCommonInputs'


### PR DESCRIPTION
We decided to support linking the reward contracts to the projects. With this, we can reuse the same reward contract across quests.

With this PR we update the reward form card to support the following UX flow:

1. User selects network
2. Based on whether they have a contract available for the selected chain, we show the quest info inputs or the option to deploy a new contract

Figma: https://www.figma.com/design/KY1oPI1uvW2zOWr7RNt2JL/Dev-Portal?node-id=406-1040788&m=dev