### PR TITLE
[Fix] a link cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "UNLICENSED",
   "scripts": {
     "dev": "vite",

--- a/src/styles/designSystem/_colors.scss
+++ b/src/styles/designSystem/_colors.scss
@@ -221,5 +221,4 @@ body {
 a:-webkit-any-link {
   color: inherit;
   text-decoration: none;
-  cursor: inherit;
 }


### PR DESCRIPTION
Can't set cursor pointer on a link with this because its specificity is higher than most other selectors used to set this.