### PR TITLE
[Quests] Make percent dynamic in quest details

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.5.37",
+  "version": "1.5.38",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/QuestDetails/QuestDetails.stories.tsx
+++ b/src/components/QuestDetails/QuestDetails.stories.tsx
@@ -211,7 +211,8 @@ export const PlayStreak: Story = {
             playStreak: {
               currentStreakInDays: 2,
               requiredStreakInDays: 7,
-              getResetTimeInMsSinceEpoch: getNextMidnightTimestamp
+              getResetTimeInMsSinceEpoch: getNextMidnightTimestamp,
+              getDailySessionPercentCompleted: () => 40
             }
           }}
           questType="PLAYSTREAK"

--- a/src/components/QuestDetails/components/StreakProgress/StreakProgress.stories.tsx
+++ b/src/components/QuestDetails/components/StreakProgress/StreakProgress.stories.tsx
@@ -105,3 +105,20 @@ export const PlayStreak25DaysCompletesIn2Seconds: Story = {
     )
   }
 }
+
+export const PlayStreakDaily100PctButNotCompleted: Story = {
+  args: { ...props },
+  render: (args) => {
+    return (
+      <div>
+        <StreakProgress
+          {...args}
+          currentStreakInDays={10}
+          requiredStreakInDays={25}
+          getResetTimeInMsSinceEpoch={() => Date.now().valueOf() + 2000}
+          getDailySessionPercentCompleted={() => 100}
+        />
+      </div>
+    )
+  }
+}

--- a/src/components/QuestDetails/components/StreakProgress/StreakProgress.stories.tsx
+++ b/src/components/QuestDetails/components/StreakProgress/StreakProgress.stories.tsx
@@ -16,7 +16,7 @@ const props: StreakProgressProps = {
   currentStreakInDays: 7,
   requiredStreakInDays: 7,
   getResetTimeInMsSinceEpoch: getNextMidnightTimestamp,
-  dailySessionPercentCompleted: 80
+  getDailySessionPercentCompleted: () => 80
 }
 
 export const Default: Story = {
@@ -65,7 +65,7 @@ export const PlayStreakNotStarted: Story = {
           currentStreakInDays={0}
           requiredStreakInDays={7}
           getResetTimeInMsSinceEpoch={getNextMidnightTimestamp}
-          dailySessionPercentCompleted={30}
+          getDailySessionPercentCompleted={() => 30}
         />
       </div>
     )
@@ -82,7 +82,7 @@ export const PlayStreak23Days: Story = {
           currentStreakInDays={12}
           requiredStreakInDays={23}
           getResetTimeInMsSinceEpoch={getNextMidnightTimestamp}
-          dailySessionPercentCompleted={1}
+          getDailySessionPercentCompleted={() => 1}
         />
       </div>
     )
@@ -99,7 +99,7 @@ export const PlayStreak25DaysCompletesIn2Seconds: Story = {
           currentStreakInDays={10}
           requiredStreakInDays={25}
           getResetTimeInMsSinceEpoch={() => Date.now().valueOf() + 2000}
-          dailySessionPercentCompleted={84}
+          getDailySessionPercentCompleted={() => 84}
         />
       </div>
     )

--- a/src/components/QuestDetails/components/StreakProgress/index.tsx
+++ b/src/components/QuestDetails/components/StreakProgress/index.tsx
@@ -96,6 +96,10 @@ export default function StreakProgress({
     ctaText = i18n.streakCompleted
   }
 
+  if (dailySessionPercentCompleted >= 100) {
+    lightningBoltCircleClass = styles.finished
+  }
+
   let rewardCountdownContainer = null
   if (!questFinished) {
     rewardCountdownContainer = (

--- a/src/components/QuestDetails/components/StreakProgress/index.tsx
+++ b/src/components/QuestDetails/components/StreakProgress/index.tsx
@@ -103,8 +103,10 @@ export default function StreakProgress({
     ctaText = i18n.streakCompleted
   }
 
+  let progressCompletedColor = 'var(--color-alert-300)'
   if (dailySessionPercentCompleted >= 100) {
     lightningBoltCircleClass = styles.finished
+    progressCompletedColor = 'var(--color-success-300)'
   }
 
   let rewardCountdownContainer = null
@@ -161,7 +163,7 @@ export default function StreakProgress({
           sections={[
             {
               value: percentCompleted,
-              color: 'var(--color-alert-300)'
+              color: progressCompletedColor
             }
           ]}
         />

--- a/src/components/QuestDetails/components/StreakProgress/index.tsx
+++ b/src/components/QuestDetails/components/StreakProgress/index.tsx
@@ -27,7 +27,7 @@ export default function StreakProgress({
   currentStreakInDays,
   requiredStreakInDays,
   getResetTimeInMsSinceEpoch,
-  dailySessionPercentCompleted,
+  getDailySessionPercentCompleted,
   i18n = {
     streakProgress: 'Streak Progress',
     days: 'days',
@@ -55,14 +55,21 @@ export default function StreakProgress({
   }
   const [timeLeftString, setTimeLeftString] = useState(getTimeLeftString())
 
-  function updateTimeLeft() {
+  const [dailySessionPercentCompleted, setDailySessionPercentCompleted] =
+    useState(getDailySessionPercentCompleted())
+
+  function update() {
     if (!questFinished) {
       setTimeLeftString(getTimeLeftString())
+    }
+
+    if (dailySessionPercentCompleted < 100) {
+      setDailySessionPercentCompleted(getDailySessionPercentCompleted())
     }
   }
 
   useEffect(() => {
-    const interval = setInterval(() => updateTimeLeft(), 1000)
+    const interval = setInterval(() => update(), 1000)
     return () => clearInterval(interval)
   }, [])
 

--- a/src/components/QuestDetails/types.ts
+++ b/src/components/QuestDetails/types.ts
@@ -22,7 +22,7 @@ export interface PlayStreakEligibility {
   currentStreakInDays: number
   requiredStreakInDays: number
   getResetTimeInMsSinceEpoch: () => number
-  dailySessionPercentCompleted: number
+  getDailySessionPercentCompleted: () => number
 }
 
 export interface QuestReward {


### PR DESCRIPTION
# Summary
- While the user is playing, percentage should update as they play the game
- Lightning bolt should be green at >= 100% completion for the day