### PR TITLE
fix(collapse): make whole content clickable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/Collapse/Collapse.module.scss
+++ b/src/components/Collapse/Collapse.module.scss
@@ -1,10 +1,9 @@
 .root {
   width: 100%;
   display: flex;
-  padding: var(--space-xs) var(--space-md);
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--space-2lg);
+  gap: var(--space-md);
   align-self: stretch;
   border-radius: var(--space-xs);
   border: 2px solid var(--color-neutral-600);
@@ -19,6 +18,7 @@
   align-self: stretch;
   text-align: left;
   cursor: pointer;
+  padding: var(--space-xs) var(--space-md);
 }
 
 .info {
@@ -36,6 +36,8 @@
 
 .content {
   width: 100%;
+  padding: var(--space-xs) var(--space-md);
+  padding-top: 0;
 }
 
 .buttonTitle {

--- a/src/components/Collapse/index.tsx
+++ b/src/components/Collapse/index.tsx
@@ -78,7 +78,11 @@ const Collapse = ({
     >
       <button
         {...props}
-        className={cn(styles.toggleButton, classNames?.toggleButton)}
+        className={cn(
+          styles.toggleButton,
+          classNames?.toggleButton,
+          isOpen && styles.buttonOpen
+        )}
         onClick={handleToggle}
         onKeyDown={handleKeyDown}
         tabIndex={0}


### PR DESCRIPTION
Currently the button doesn't have any padding, the container does and as a result clicking the padding in the container doesn't trigger the collapse action.

By moving the padding to the button we can achieve making the padding space clickable.

Story: https://hyperplay-ui-git-fix-collapse-clickable-area-hyperplay.vercel.app/?path=/docs/collapse--docs
