### PR TITLE
[Fix] rm search memo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 
 import { Popover } from '@mantine/core'
 import classNames from 'classnames'
@@ -54,14 +54,7 @@ export default function SearchBar({
   }
 
   const showClearButton = searchText.length > 0
-  const gameList = useMemo(() => {
-    if (suggestions && searchText.length > 0) {
-      return suggestions.filter((el) =>
-        el.toLowerCase().includes(searchText.toLowerCase())
-      )
-    }
-    return []
-  }, [suggestions, searchText])
+  const gameList = suggestions ?? []
 
   const handleOnClickSuggestion = (suggestion: string) => {
     if (onClickSuggestion) {
@@ -118,10 +111,7 @@ export default function SearchBar({
           />
           {showClearButton && (
             <button className={styles.clearButton} onClick={clearSearch}>
-              <CloseButton
-                fill="var(--color-neutral-400)"
-                onClick={clearSearch}
-              />
+              <CloseButton fill="var(--color-neutral-400)" />
             </button>
           )}
         </div>


### PR DESCRIPTION
The search memo prevents searching for a field that isn't the same field as in the suggestions dropdown

For instance, we are searching for game title and quest title matches on the quest summary page. This will show as no results for the game title suggestions in the popover.

Ultimately this is just too opinionated for a stateless ui library component


An on click handler is not needed on the svg either and throws a eslint error, so I removed it.