### PR TITLE
[Tech] decouple search bar from quests summary table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/QuestsSummaryTable/QuestsSummaryTable.stories.tsx
+++ b/src/components/QuestsSummaryTable/QuestsSummaryTable.stories.tsx
@@ -9,6 +9,7 @@ import reCard from '@/assets/steamCards/residentEvilCard.jpg?url'
 import { QuestsSummaryTable, QuestsSummaryTableProps } from '.'
 import { itemType } from '../Dropdowns/Dropdown'
 import { QuestCard, QuestCardProps } from '../QuestCard'
+import SearchBar from '../SearchBar'
 
 const meta: Meta<typeof QuestsSummaryTable> = {
   title: 'Quests/QuestsSummaryTable',
@@ -123,15 +124,22 @@ export const SearchDemo: Story = {
     const gameElementsFiltered = gamesFiltered.map(({ id, ...rest }) => (
       <QuestCard key={id} {...rest} />
     ))
+    const searchBar = (
+      <SearchBar
+        searchText={searchText}
+        setSearchText={setSearchText}
+        i18n={{ placeholder: 'Search Quest' }}
+        styles={{ container: { margin: '0px 0px 0px auto' } }}
+        suggestions={gamesFiltered
+          .filter((val) => !!val.title)
+          .map((val) => val.title!)}
+      />
+    )
     return (
       <QuestsSummaryTable
         {...args}
         games={gameElementsFiltered}
-        setSearchText={setSearchText}
-        searchText={searchText}
-        searchSuggestions={gamesFiltered
-          .filter((val) => !!val.title)
-          .map((val) => val.title!)}
+        searchBar={searchBar}
       />
     )
   }

--- a/src/components/QuestsSummaryTable/index.module.scss
+++ b/src/components/QuestsSummaryTable/index.module.scss
@@ -102,8 +102,3 @@
   flex-direction: row;
   gap: var(--space-2lg-fixed);
 }
-
-.searchBarRoot {
-  background-color: transparent;
-  margin: 0px 0px 0px auto;
-}

--- a/src/components/QuestsSummaryTable/index.tsx
+++ b/src/components/QuestsSummaryTable/index.tsx
@@ -10,7 +10,6 @@ import MessageModal, {
 import { Dropdown } from '../Dropdowns'
 import { DropdownProps } from '../Dropdowns/Dropdown'
 import Loading from '../Loading'
-import SearchBar from '../SearchBar'
 import { Tabs, getTabsClassNames } from '../Tabs'
 import styles from './index.module.scss'
 
@@ -41,12 +40,7 @@ export interface QuestsSummaryTableProps
   classNames?: {
     title?: string
   }
-  searchText?: string
-  setSearchText?: (text: string) => void
-  searchSuggestions?: string[]
-  i18n?: {
-    searchPlaceholder: string
-  }
+  searchBar?: JSX.Element
 }
 
 export function QuestsSummaryTable({
@@ -64,10 +58,7 @@ export function QuestsSummaryTable({
   activeTab,
   pageTitle,
   classNames,
-  searchText,
-  setSearchText,
-  searchSuggestions,
-  i18n = { searchPlaceholder: 'Search Quest' },
+  searchBar,
   ...rest
 }: QuestsSummaryTableProps) {
   const fetchMoreOnBottomReached: React.UIEventHandler<HTMLDivElement> = (
@@ -110,19 +101,6 @@ export function QuestsSummaryTable({
     )
   } else {
     content = gamesComponent
-  }
-
-  let searchBar = null
-  if (searchText !== undefined && setSearchText !== undefined) {
-    searchBar = (
-      <SearchBar
-        searchText={searchText}
-        setSearchText={setSearchText}
-        i18n={{ placeholder: i18n.searchPlaceholder }}
-        containerClass={styles.searchBarRoot}
-        suggestions={searchSuggestions}
-      />
-    )
   }
 
   return (

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useRef } from 'react'
+import React, { CSSProperties, useEffect, useRef } from 'react'
 
 import { Popover, PopoverProps } from '@mantine/core'
 import cn from 'classnames'
 
 import { CloseButton, MagnifyingGlass } from '@/assets/images'
 
-import styles from './SearchBar.module.scss'
+import searchBarStyles from './SearchBar.module.scss'
 
 interface Props extends PopoverProps {
   searchText: string
@@ -15,11 +15,16 @@ interface Props extends PopoverProps {
   i18n: {
     placeholder: string
   }
-  containerClass?: string
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>
   classNames?: {
     dropdown?: string
     arrow?: string
+    container?: string
+  }
+  styles?: {
+    dropdown?: CSSProperties
+    arrow?: CSSProperties
+    container?: CSSProperties
   }
 }
 
@@ -29,9 +34,9 @@ export default function SearchBar({
   i18n: { placeholder },
   suggestions,
   onClickSuggestion,
-  containerClass,
   inputProps,
   classNames,
+  styles,
   ...props
 }: Props) {
   const input = useRef<HTMLInputElement>(null)
@@ -81,7 +86,7 @@ export default function SearchBar({
           <button
             onClick={() => handleOnClickSuggestion(el)}
             key={el}
-            className={styles.searchResult}
+            className={searchBarStyles.searchResult}
           >
             {el}
           </button>
@@ -93,14 +98,14 @@ export default function SearchBar({
   }
 
   const dropdownClassnames: Record<string, boolean> = {}
-  dropdownClassnames[styles.hideDropdown] = searchResults === null
+  dropdownClassnames[searchBarStyles.hideDropdown] = searchResults === null
 
   return (
     <Popover
       width="target"
       classNames={{
         dropdown: cn(
-          styles.popoverDropdown,
+          searchBarStyles.popoverDropdown,
           dropdownClassnames,
           classNames?.dropdown
         ),
@@ -110,8 +115,11 @@ export default function SearchBar({
       {...props}
     >
       <Popover.Target>
-        <div className={cn(styles.searchBar, containerClass)}>
-          <button className={styles.searchButton}>
+        <div
+          className={cn(searchBarStyles.searchBar, classNames?.container)}
+          style={styles?.container}
+        >
+          <button className={searchBarStyles.searchButton}>
             <MagnifyingGlass fill="var(--color-neutral-400)" />
           </button>
           <input
@@ -123,14 +131,19 @@ export default function SearchBar({
             value={searchText}
           />
           {showClearButton && (
-            <button className={styles.clearButton} onClick={clearSearch}>
+            <button
+              className={searchBarStyles.clearButton}
+              onClick={clearSearch}
+            >
               <CloseButton fill="var(--color-neutral-400)" />
             </button>
           )}
         </div>
       </Popover.Target>
       <Popover.Dropdown>
-        <div className={styles.popoverDropdownList}>{searchResults}</div>
+        <div className={searchBarStyles.popoverDropdownList}>
+          {searchResults}
+        </div>
       </Popover.Dropdown>
     </Popover>
   )


### PR DESCRIPTION
# Summary

Decouple search bar from summary table.

Needed so that I can set `withinPortal` on the search bar for the store page scrolling, which is only needed on the store page. 