### PR TITLE
feat(quest-streak-progress): add support for right section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/QuestDetails/components/StreakProgress/StreakProgress.stories.tsx
+++ b/src/components/QuestDetails/components/StreakProgress/StreakProgress.stories.tsx
@@ -1,6 +1,8 @@
 import { oneDayInMs } from '@hyperplay/utils'
 import type { Meta, StoryObj } from '@storybook/react'
 
+import Button from '@/components/Button'
+
 import StreakProgress, { StreakProgressProps } from '.'
 
 const meta: Meta<typeof StreakProgress> = {
@@ -141,7 +143,18 @@ export const WithExternalStreakButton: Story = {
   render: (args) => {
     return (
       <div>
-        <StreakProgress {...args} showSyncProgressButton={true} />
+        <StreakProgress
+          {...args}
+          rightSection={
+            <Button
+              type="secondaryGradient"
+              onClick={() => alert('Syncing...')}
+              size="small"
+            >
+              Sync progress
+            </Button>
+          }
+        />
       </div>
     )
   }

--- a/src/components/QuestDetails/components/StreakProgress/index.module.scss
+++ b/src/components/QuestDetails/components/StreakProgress/index.module.scss
@@ -33,6 +33,14 @@ $rootPadding: var(--space-md-fixed);
   }
 }
 
+.progressIconsContainer {
+  display: grid;
+  gap: var(--space-xs);
+  grid-template-columns: repeat(12, auto);
+  grid-template-rows: repeat(2, auto);
+  column-gap: 0px;
+}
+
 .clock {
   stroke: var(--color-neutral-400);
 }

--- a/src/components/QuestDetails/components/StreakProgress/index.module.scss
+++ b/src/components/QuestDetails/components/StreakProgress/index.module.scss
@@ -74,7 +74,7 @@ $rootPadding: var(--space-md-fixed);
   }
 }
 
-.syncContainer {
+.rightSection {
   display: flex;
   justify-content: flex-end;
 }

--- a/src/components/QuestDetails/components/StreakProgress/index.tsx
+++ b/src/components/QuestDetails/components/StreakProgress/index.tsx
@@ -9,7 +9,6 @@ import { RingProgress } from '@mantine/core'
 import classNames from 'classnames'
 
 import { Clock, LightningBolt } from '@/assets/images'
-import Button from '@/components/Button'
 
 import { PlayStreakEligibility } from '../../types'
 import styles from './index.module.scss'
@@ -28,6 +27,34 @@ export interface StreakProgressI18n {
 
 export interface StreakProgressProps extends PlayStreakEligibility {
   i18n?: StreakProgressI18n
+}
+
+function PlayStreakBolts({
+  currentStreakInDays,
+  requiredStreakInDays
+}: {
+  currentStreakInDays: number
+  requiredStreakInDays: number
+}) {
+  const lightningBoltIcons: boolean[] = []
+
+  if (requiredStreakInDays <= 24) {
+    for (let i = 0; i < requiredStreakInDays; ++i) {
+      lightningBoltIcons.push(i < currentStreakInDays)
+    }
+  }
+
+  return (
+    <div className={styles.progressIconsContainer}>
+      {lightningBoltIcons.map((filled, index) => (
+        <LightningBolt
+          className={classNames(styles.streakIcon, filled && styles.filled)}
+          key={`lightningBolt:${index}`}
+        />
+      ))}
+      <LightningBolt />
+    </div>
+  )
 }
 
 export default function StreakProgress({
@@ -145,7 +172,12 @@ export default function StreakProgress({
         </div>
         {rightSection ? (
           <div className={styles.rightSection}>{rightSection}</div>
-        ) : null}
+        ) : (
+          <PlayStreakBolts
+            currentStreakInDays={currentStreakInDays}
+            requiredStreakInDays={requiredStreakInDays}
+          />
+        )}
       </div>
       <hr></hr>
       <div className={classNames('body-sm', styles.bottomContainer)}>

--- a/src/components/QuestDetails/components/StreakProgress/index.tsx
+++ b/src/components/QuestDetails/components/StreakProgress/index.tsx
@@ -37,7 +37,7 @@ export default function StreakProgress({
   accumulatedPlaytimeTodayInSeconds,
   lastPlaySessionCompletedDateTimeUTC,
   dateTimeCurrentSessionStartedInMsSinceEpoch,
-  showSyncProgressButton,
+  rightSection,
   i18n = {
     streakProgress: 'Streak Progress',
     days: 'days',
@@ -48,8 +48,7 @@ export default function StreakProgress({
     now: 'Now',
     dayResets: 'Day resets:',
     sync: 'Sync Progress'
-  },
-  onSync
+  }
 }: StreakProgressProps) {
   ;({ requiredStreakInDays, currentStreakInDays } = getPlayStreakDays({
     lastPlaySessionCompletedDateTimeUTC,
@@ -144,12 +143,8 @@ export default function StreakProgress({
             {` / ${requiredStreakInDays} ${i18n.days}`}
           </div>
         </div>
-        {showSyncProgressButton ? (
-          <div className={styles.syncContainer}>
-            <Button type="secondaryGradient" onClick={onSync} size="small">
-              {i18n.sync}
-            </Button>
-          </div>
+        {rightSection ? (
+          <div className={styles.rightSection}>{rightSection}</div>
         ) : null}
       </div>
       <hr></hr>

--- a/src/components/QuestDetails/types.ts
+++ b/src/components/QuestDetails/types.ts
@@ -26,8 +26,7 @@ export interface PlayStreakEligibility {
   accumulatedPlaytimeTodayInSeconds: number
   lastPlaySessionCompletedDateTimeUTC: string
   dateTimeCurrentSessionStartedInMsSinceEpoch?: number
-  onSync: () => void
-  showSyncProgressButton?: boolean
+  rightSection?: React.ReactNode
 }
 
 export interface QuestReward {


### PR DESCRIPTION
- Add support for passing a right section component. This will let us pass components conditionally
![image](https://github.com/user-attachments/assets/b5b57c19-41a4-4a2d-b852-735014f1a6c9)
![image](https://github.com/user-attachments/assets/b5496494-54f1-48a6-9e4a-5ec9b206dc18)

- Default to the playstreak bolts