### PR TITLE
fix(quest-details): show num claims left

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/QuestDetails/components/Reward/index.module.scss
+++ b/src/components/QuestDetails/components/Reward/index.module.scss
@@ -1,4 +1,11 @@
 $imgSize: 160px;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
 .rewardContainer {
   max-width: $imgSize;
   max-height: $imgSize;
@@ -6,7 +13,6 @@ $imgSize: 160px;
   height: $imgSize;
   border-radius: var(--space-xs);
   position: relative;
-  margin-bottom: var(--space-md);
   overflow: hidden;
 
   &:hover .viewRewardContainer {

--- a/src/components/QuestDetails/components/Reward/index.tsx
+++ b/src/components/QuestDetails/components/Reward/index.tsx
@@ -46,25 +46,27 @@ export default function Reward({ reward, i18n }: RewardProps) {
   }
 
   return (
-    <div key={reward.title} className={styles.rewardContainer}>
-      {reward.isClaimed ? (
-        <div className={styles.isClaimed}>{i18n.claimed}</div>
-      ) : null}
-      {reward.marketplaceUrl ? (
-        <a
-          href={reward.marketplaceUrl}
-          className={styles.viewRewardContainer}
-          rel="nooepner noreferrer"
-          target="_blank"
-        >
-          <LinkExternal className={styles.linkExternalIcon} />
-          {i18n.viewReward}
-        </a>
-      ) : null}
-      <img src={reward.imageUrl} />
-      <div className={classNames(styles.titleContainer, 'menu')}>
-        <div className={styles.title}>{reward.title}</div>
-        {numToClaimComponent}
+    <div className={styles.container}>
+      <div key={reward.title} className={styles.rewardContainer}>
+        {reward.isClaimed ? (
+          <div className={styles.isClaimed}>{i18n.claimed}</div>
+        ) : null}
+        {reward.marketplaceUrl ? (
+          <a
+            href={reward.marketplaceUrl}
+            className={styles.viewRewardContainer}
+            rel="nooepner noreferrer"
+            target="_blank"
+          >
+            <LinkExternal className={styles.linkExternalIcon} />
+            {i18n.viewReward}
+          </a>
+        ) : null}
+        <img src={reward.imageUrl} />
+        <div className={classNames(styles.titleContainer, 'menu')}>
+          <div className={styles.title}>{reward.title}</div>
+          {numToClaimComponent}
+        </div>
       </div>
       {numClaimsLeftComponent}
     </div>

--- a/src/components/QuestDetails/components/Reward/index.tsx
+++ b/src/components/QuestDetails/components/Reward/index.tsx
@@ -46,8 +46,8 @@ export default function Reward({ reward, i18n }: RewardProps) {
   }
 
   return (
-    <div className={styles.container}>
-      <div key={reward.title} className={styles.rewardContainer}>
+    <div className={styles.container} key={reward.title}>
+      <div className={styles.rewardContainer}>
         {reward.isClaimed ? (
           <div className={styles.isClaimed}>{i18n.claimed}</div>
         ) : null}


### PR DESCRIPTION
The claims left text has always been there but we were placing it inside of the reward image which has `overflow: hidden`. Wrapping the components with a flex container solves the issue.

Preview: https://hyperplay-ui-git-fix-claims-left-hyperplay.vercel.app/?path=/story/quests-questdetails--play-streak