### PR TITLE
[Fix] Storybook tests

### DIFF
--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -8,12 +8,12 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Needed to downgrade the ubuntu runner since some of the playwright dependencies are not available on the latest version of ubuntu.
This doesn't affect anything though sine the headless browsers are the same on both ubuntu versions.