### PR TITLE
[UI] Add new badge colors

### DIFF
--- a/src/components/Sticker/index.module.scss
+++ b/src/components/Sticker/index.module.scss
@@ -3,6 +3,27 @@
   display: inline-block;
 }
 
+.neutral {
+  color: var(--color-neutral-400);
+  border-radius: var(--corner-round, 100px);
+  border: 2px solid var(--color-neutral-400);
+
+  &.filled {
+    background-color: var(--color-neutral-400);
+    color: var(--color-neutral-700);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
+  }
+
+  &.filledStrong {
+    background-color: var(--color-neutral-600);
+    color: var(--color-neutral-300);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
+  }
+}
 .secondary {
   color: var(--color-primary-200);
   border-radius: var(--corner-round, 100px);
@@ -10,7 +31,60 @@
 
   &.filled {
     background-color: var(--color-primary-200);
-    color: var(--color-neutral-800);
+    color: var(--color-primary-800);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
+  }
+  &.filledStrong {
+    background-color: var(--color-primary-600);
+    color: var(--color-primary-100);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
+  }
+}
+
+.tertiary {
+  color: var(--color-tertiary-400);
+  border-radius: var(--corner-round, 100px);
+  border: 2px solid var(--color-tertiary-400);
+
+  &.filled {
+    background-color: var(--color-tertiary-400);
+    color: var(--color-tertiary-800);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
+  }
+
+  &.filledStrong {
+    background-color: var(--color-tertiary-800);
+    color: var(--color-tertiary-100);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
+  }
+}
+
+.success {
+  color: var(--color-success-300);
+  border-radius: var(--corner-round, 100px);
+  border: 2px solid var(--color-success-300);
+
+  &.filled {
+    background: var(--color-success-300);
+    color: var(--color-success-900);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
+  }
+  &.filledStrong {
+    background-color: var(--color-success-900);
+    color: var(--color-success-100);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
   }
 }
 
@@ -21,17 +95,38 @@
 
   &.filled {
     background: var(--color-alert-400);
-    color: var(--color-neutral-900);
+    color: var(--color-alert-900);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
+  }
+  &.filledStrong {
+    background-color: var(--color-alert-700);
+    color: var(--color-alert-100);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
   }
 }
 
-.success {
-  color: var(--color-success-500);
+.error {
+  color: var(--color-error-400);
   border-radius: var(--corner-round, 100px);
-  border: 2px solid var(--color-success-500);
+  border: 2px solid var(--color-error-400);
 
   &.filled {
-    background: var(--color-success-500);
-    color: var(--color-neutral-900);
+    background: var(--color-error-400);
+    color: var(--color-error-900);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
+  }
+
+  &.filledStrong {
+    background-color: var(--color-error-700);
+    color: var(--color-error-100);
+    border-radius: var(--corner-round, 4px);
+    font-weight: var(--bold);
+    border: none;
   }
 }

--- a/src/components/Sticker/index.tsx
+++ b/src/components/Sticker/index.tsx
@@ -5,8 +5,14 @@ import classNames from 'classnames'
 import styles from './index.module.scss'
 
 export interface StickerProps extends HTMLProps<HTMLDivElement> {
-  styleType: 'secondary' | 'warning' | 'success'
-  variant: 'filled' | 'default' | 'outlined'
+  styleType:
+    | 'neutral'
+    | 'secondary'
+    | 'tertiary'
+    | 'success'
+    | 'warning'
+    | 'error'
+  variant: 'filled' | 'default' | 'outlined' | 'filledStrong'
 }
 
 export default function Sticker({
@@ -16,11 +22,15 @@ export default function Sticker({
   ...props
 }: StickerProps) {
   const divClasses: Record<string, boolean> = {}
+  divClasses[styles.neutral] = styleType === 'neutral'
   divClasses[styles.secondary] = styleType === 'secondary'
-  divClasses[styles.warning] = styleType === 'warning'
+  divClasses[styles.tertiary] = styleType === 'tertiary'
   divClasses[styles.success] = styleType === 'success'
+  divClasses[styles.warning] = styleType === 'warning'
+  divClasses[styles.error] = styleType === 'error'
   divClasses[styles.outlined] = variant === 'outlined'
   divClasses[styles.filled] = variant === 'filled'
+  divClasses[styles.filledStrong] = variant === 'filledStrong'
   return (
     <div
       {...props}


### PR DESCRIPTION
This pr is to add the neutral, tertiary, and error badge colors, besides the filledStrong variant, which matches the DS and is needed in some other new components. 

DS: 
![image](https://github.com/user-attachments/assets/fc6b1171-9bff-4d84-adfe-7efe7dd5affe)

Storybook:
![image](https://github.com/user-attachments/assets/c06e923a-0c16-4708-b788-9a66026e4ba0)

