### PR TITLE
[Feature] Add game name to quest details component 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/QuestDetails/QuestDetails.stories.tsx
+++ b/src/components/QuestDetails/QuestDetails.stories.tsx
@@ -130,6 +130,7 @@ const rewardsComponent = <Rewards>{rewardsContent}</Rewards>
 const props: QuestDetailsProps = {
   isSignedIn: true,
   title: 'Eternal Ember: Shadows of the Celestial Nexus',
+  gameTitle: 'Game title',
   description:
     'Shadows of the Celestial NexusEmbark on a cosmic odyssey as the chosen guardian of the Eternal Ember. Traverse astral realms, unravel celestial mysteries, and confront shadowy entities threatening the balance of the Celestial Nexus. Master arcane powers, forge alliances with otherworldly beings, and navigate intricate puzzles. \n \nWill you rise to the challenge and become the savior of the Celestial Nexus, or succumb to the shadows that threaten to engulf the eternal flame?',
   eligibilityComponent: [

--- a/src/components/QuestDetails/index.module.scss
+++ b/src/components/QuestDetails/index.module.scss
@@ -5,13 +5,12 @@
   margin: var(--space-xl) var(--space-xs);
 }
 
-.container {
+.badges {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-2lg);
-  align-items: flex-start;
-  flex-grow: 1;
-  overflow-y: auto;
+  flex-direction: row;
+  align-items: start;
+  gap: var(--space-xs);
+  margin-top: var(--space-xs);
 }
 
 .claimButton {

--- a/src/components/QuestDetails/index.module.scss
+++ b/src/components/QuestDetails/index.module.scss
@@ -10,7 +10,6 @@
   flex-direction: row;
   align-items: start;
   gap: var(--space-xs);
-  margin-top: var(--space-xs);
 }
 
 .claimButton {
@@ -58,5 +57,5 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  gap: var(--space-2xl);
+  gap: var(--space-xl);
 }

--- a/src/components/QuestDetails/index.tsx
+++ b/src/components/QuestDetails/index.tsx
@@ -50,6 +50,7 @@ export default function QuestDetails({
   isSyncing,
   steamAccountIsLinked,
   rewardsComponent,
+  gameTitle,
   ...props
 }: QuestDetailsProps) {
   let sticker = null
@@ -75,6 +76,7 @@ export default function QuestDetails({
         ctaClick = onConnectSteamAccountClick
       }
     }
+
     // if this is a play streak quest
   } else if (questType === 'PLAYSTREAK') {
     sticker = (
@@ -96,6 +98,13 @@ export default function QuestDetails({
         ? () => console.log('play click handler not set!')
         : onPlayClick
   }
+
+  // Game Title Badge
+  const gameNameSticker = (
+    <Sticker styleType="neutral" variant="outlined">
+      {gameTitle}
+    </Sticker>
+  )
 
   let primaryCTAButtonType: ButtonProps['type'] = 'secondary'
   if (showSync && onSyncClick) {
@@ -133,17 +142,18 @@ export default function QuestDetails({
 
   let content = (
     <div className={cn(styles.rootContent, classNames?.rootContent)}>
-      <div className={cn(styles.container, classNames?.content)}>
-        {sticker}
-        <div className={cn('title', styles.title)}>{title}</div>
-        <div className={cn('body-sm', 'color-neutral-400', styles.description)}>
-          {description}
-        </div>
-
-        {eligibilityComponent}
-        {rewardsComponent}
-        {errorAlert}
+      <div className={styles.badges}>
+        <p className={cn(classNames?.content)}>{gameNameSticker}</p>
+        <p className={cn(classNames?.content)}>{sticker}</p>
       </div>
+      <div className={cn('title', styles.title)}>{title}</div>
+      <div className={cn('body-sm', 'color-neutral-400', styles.description)}>
+        {description}
+      </div>
+
+      {eligibilityComponent}
+      {rewardsComponent}
+      {errorAlert}
       <div className={styles.ctaContainer}>
         {ctaComponent ?? (
           <>
@@ -163,6 +173,7 @@ export default function QuestDetails({
       </div>
     </div>
   )
+
   if (loading) {
     content = <Loading className={cn(styles.loader, classNames?.loading)} />
   }

--- a/src/components/QuestDetails/types.ts
+++ b/src/components/QuestDetails/types.ts
@@ -58,6 +58,7 @@ export interface QuestDetailsTranslations {
 
 export interface QuestDetailsProps extends HTMLProps<HTMLDivElement> {
   title: string
+  gameTitle: string
   description: React.ReactNode | string
   eligibilityComponent: ReactNode
   rewardsComponent: ReactNode


### PR DESCRIPTION
### UI Component

This PR adds the component on Storybook, I need this approved for use in the Client repository.

### How to test
- Click on the  Storybook review link and search for the "QuestDetails" component

### Design
![image](https://github.com/user-attachments/assets/3e4bc66d-4b76-4f98-9737-0a80f6e3cee0)




