### PR TITLE
[UI] Remove title rendering and make title optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -18,12 +18,11 @@ export default {
 const items: SlideData[] = [
   {
     slideElement: <img src={pgCover} />,
-    title: 'Phantom Galaxies',
     button: <Button>View Game</Button>
   },
-  { slideElement: <img src={dtCover} />, title: 'Dark Throne' },
-  { slideElement: <img src={wakeCover} />, title: 'The Wake' },
-  { slideElement: <img src={onisCover} />, title: 'Onis Quest' }
+  { slideElement: <img src={dtCover} /> },
+  { slideElement: <img src={wakeCover} /> },
+  { slideElement: <img src={onisCover} /> }
 ]
 
 export const Default = () => (

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -8,7 +8,7 @@ import Controller from './components/Controller'
 import styles from './index.module.scss'
 
 export interface SlideData {
-  title: string
+  title?: string
   slideElement: JSX.Element
   thumbnail?: JSX.Element
   disableGradient?: boolean
@@ -53,10 +53,7 @@ const Carouselv2 = ({
         id={item.disableGradient ? 'disableGradient' : 'enableGradient'}
       >
         {item.slideElement}
-        <div className={styles.title}>
-          <div className={styles.titleText}>{item.title}</div>
-          {item.button ?? null}
-        </div>
+        {item.button && <div className={styles.title}>{item.button}</div>}
       </Carousel.Slide>
     ))
   }

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react'
 
 import { Carousel } from '@mantine/carousel'
+import type { EmblaCarouselType } from 'embla-carousel'
 import Autoplay, { AutoplayType } from 'embla-carousel-autoplay'
-import { EmblaCarouselType } from 'embla-carousel-react'
 
 import Controller from './components/Controller'
 import styles from './index.module.scss'
 
 export interface SlideData {
-  title?: string
   slideElement: JSX.Element
   thumbnail?: JSX.Element
   disableGradient?: boolean


### PR DESCRIPTION
## Description

This pr removes the Game Title from the carousel in the Storybook, the next step is to update it in the client. 

### Before
![image](https://github.com/user-attachments/assets/9e72264c-6fd9-4095-99a2-911a2b872172)

### After
![image](https://github.com/user-attachments/assets/41e9be27-9bdc-4bec-ae94-b448a1ae7380)

