### PR TITLE
[fix]: Fix platform icons on GameInfo component

### DIFF
--- a/src/components/GameInfo/GameInfo.module.scss
+++ b/src/components/GameInfo/GameInfo.module.scss
@@ -46,6 +46,8 @@
 
 .platformInfo {
   display: flex;
+  align-items: center;
+  justify-content: flex-end;
   gap: var(--space-xs);
 
   svg {


### PR DESCRIPTION
## Description

This pr is a simple fix to center align the platform icons on the GameInfo component showed in the Game Details Page.

### Before
![image](https://github.com/user-attachments/assets/254edff7-32e1-47e3-8691-89ab03e41e6f)

### After 
![image](https://github.com/user-attachments/assets/4ecda688-182d-47a0-b77c-b0f28bf434c9)
