### PR TITLE
[Fix] Streak progress when not playing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",
@@ -139,5 +139,6 @@
     "@tabler/icons-react": "^2.46.0",
     "@valist/sdk": "^2.9.1",
     "ethereum-blockies-base64": "^1.0.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/StreakProgress/StreakProgress.stories.tsx
+++ b/src/components/StreakProgress/StreakProgress.stories.tsx
@@ -22,11 +22,21 @@ const props: StreakProgressProps = {
   lastPlaySessionCompletedDateTimeUTC: new Date(
     Date.now() - oneDayInMs
   ).toUTCString(),
-  dateTimeCurrentSessionStartedInMsSinceEpoch: Date.now()
+  dateTimeCurrentSessionStartedInMsSinceEpoch: Date.now(),
+  streakIsProgressing: true
 }
 
 export const Default: Story = {
   args: { ...props }
+}
+
+export const PlaystreakWhenUserNotPlaying: Story = {
+  args: {
+    ...props,
+    currentStreakInDays: 2,
+    requiredStreakInDays: 7,
+    streakIsProgressing: false
+  }
 }
 
 export const PlayStreak: Story = {

--- a/src/components/StreakProgress/index.tsx
+++ b/src/components/StreakProgress/index.tsx
@@ -27,6 +27,7 @@ export interface StreakProgressI18n {
 
 export interface StreakProgressProps extends PlayStreakEligibility {
   i18n?: StreakProgressI18n
+  streakIsProgressing?: boolean
 }
 
 function PlayStreakBolts({
@@ -65,6 +66,7 @@ export function StreakProgress({
   lastPlaySessionCompletedDateTimeUTC,
   dateTimeCurrentSessionStartedInMsSinceEpoch,
   rightSection,
+  streakIsProgressing,
   i18n = {
     streakProgress: 'Streak Progress',
     days: 'days',
@@ -115,7 +117,7 @@ export function StreakProgress({
       setTimeLeftString(getTimeLeftString())
     }
 
-    if (dailySessionPercentCompleted < 100) {
+    if (streakIsProgressing && dailySessionPercentCompleted < 100) {
       setDailySessionPercentCompleted(getDailySessionPercentCompleted())
     }
   }

--- a/src/components/StreakProgress/index.tsx
+++ b/src/components/StreakProgress/index.tsx
@@ -99,12 +99,16 @@ export function StreakProgress({
   }
   const [timeLeftString, setTimeLeftString] = useState(getTimeLeftString())
 
+  let sessionStartTime: number | undefined = undefined
+  if (streakIsProgressing) {
+    sessionStartTime = dateTimeCurrentSessionStartedInMsSinceEpoch
+  }
   const getDailySessionPercentCompleted = () =>
     getPlaytimePercentage({
       minimumSessionTimeInSeconds,
       accumulatedPlaytimeTodayInSeconds,
       lastPlaySessionCompletedDateTimeUTC,
-      dateTimeCurrentSessionStartedInMsSinceEpoch
+      dateTimeCurrentSessionStartedInMsSinceEpoch: sessionStartTime
     })
 
   const [dailySessionPercentCompleted, setDailySessionPercentCompleted] =


### PR DESCRIPTION
# Summary

add `streakIsProgressing` prop to enable the % completion interpolation which was on by default previously