### PR TITLE
[feat] Add game name to game page

### DIFF
--- a/src/components/GameAbout/GameAbout.module.scss
+++ b/src/components/GameAbout/GameAbout.module.scss
@@ -28,9 +28,5 @@
 
 .gameTitle {
   padding-bottom: var(--space-md);
-  h2 {
-    margin: 0;
-    color: var(--color-neutral-200);
-    font-size: var(--text-6xl);
-  }
+  color: var(--color-neutral-200);
 }

--- a/src/components/GameAbout/GameAbout.module.scss
+++ b/src/components/GameAbout/GameAbout.module.scss
@@ -25,3 +25,12 @@
     height: 16px;
   }
 }
+
+.gameTitle {
+  padding-bottom: var(--space-md);
+  h2 {
+    margin: 0;
+    color: var(--color-neutral-200);
+    font-size: var(--text-6xl);
+  }
+}

--- a/src/components/GameAbout/GameAbout.stories.tsx
+++ b/src/components/GameAbout/GameAbout.stories.tsx
@@ -8,11 +8,15 @@ export default {
 }
 
 export const Default = () => (
-  <GameAbout description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed" />
+  <GameAbout
+    gameName="Game Name"
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed"
+  />
 )
 
 export const LongText = () => (
   <GameAbout
+    gameName="Game Name"
     description={
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ut porttitor nisl, pulvinar mattis arcu. Nulla id augue at neque euismod rutrum ut id lorem. Maecenas blandit varius sem, at blandit ex commodo vitae. Mauris at nunc suscipit, rhoncus quam sit amet, vehicula tellus. Morbi in tempus lectus. Nulla tincidunt ante neque, dapibus ultrices elit aliquet a. Etiam cursus dolor ante, quis iaculis mi vehicula id. Etiam porta risus in leo fermentum, vitae tempus arcu convallis.\n' +
       '\n' +

--- a/src/components/GameAbout/index.tsx
+++ b/src/components/GameAbout/index.tsx
@@ -33,10 +33,14 @@ const GameAbout = ({ description, gameName, classnames }: GameAboutProps) => {
   return (
     <div className={classnames?.container}>
       {gameName && (
-        <div className={styles.gameTitle}>
-          <h2 className={classNames('h4', styles.title, classnames?.gameTitle)}>
-            {gameName}
-          </h2>
+        <div
+          className={classNames(
+            'header',
+            styles.gameTitle,
+            classnames?.gameTitle
+          )}
+        >
+          {gameName}
         </div>
       )}
       <div className={classNames('caption', classnames?.title)}>About</div>

--- a/src/components/GameAbout/index.tsx
+++ b/src/components/GameAbout/index.tsx
@@ -33,7 +33,7 @@ const GameAbout = ({ description, gameName, classnames }: GameAboutProps) => {
   return (
     <div className={classnames?.container}>
       {gameName && (
-        <header
+        <div
           className={classNames(
             'header',
             styles.gameTitle,
@@ -41,7 +41,7 @@ const GameAbout = ({ description, gameName, classnames }: GameAboutProps) => {
           )}
         >
           {gameName}
-        </header>
+        </div>
       )}
       <div className={classNames('caption', classnames?.title)}>About</div>
       <p

--- a/src/components/GameAbout/index.tsx
+++ b/src/components/GameAbout/index.tsx
@@ -31,7 +31,7 @@ const GameAbout = ({ description, gameName, classnames }: GameAboutProps) => {
   }, [])
 
   return (
-    <div className={classnames?.container}>
+    <header className={classnames?.container}>
       {gameName && (
         <div
           className={classNames(
@@ -71,7 +71,7 @@ const GameAbout = ({ description, gameName, classnames }: GameAboutProps) => {
           )}
         </button>
       )}
-    </div>
+    </header>
   )
 }
 

--- a/src/components/GameAbout/index.tsx
+++ b/src/components/GameAbout/index.tsx
@@ -31,9 +31,9 @@ const GameAbout = ({ description, gameName, classnames }: GameAboutProps) => {
   }, [])
 
   return (
-    <header className={classnames?.container}>
+    <div className={classnames?.container}>
       {gameName && (
-        <div
+        <header
           className={classNames(
             'header',
             styles.gameTitle,
@@ -41,7 +41,7 @@ const GameAbout = ({ description, gameName, classnames }: GameAboutProps) => {
           )}
         >
           {gameName}
-        </div>
+        </header>
       )}
       <div className={classNames('caption', classnames?.title)}>About</div>
       <p
@@ -71,7 +71,7 @@ const GameAbout = ({ description, gameName, classnames }: GameAboutProps) => {
           )}
         </button>
       )}
-    </header>
+    </div>
   )
 }
 

--- a/src/components/GameAbout/index.tsx
+++ b/src/components/GameAbout/index.tsx
@@ -8,10 +8,16 @@ import styles from './GameAbout.module.scss'
 
 export interface GameAboutProps {
   description: string
-  classnames?: { container?: string; title?: string; description?: string }
+  gameName?: string
+  classnames?: {
+    container?: string
+    title?: string
+    description?: string
+    gameTitle?: string
+  }
 }
 
-const GameAbout = ({ description, classnames }: GameAboutProps) => {
+const GameAbout = ({ description, gameName, classnames }: GameAboutProps) => {
   const aboutText = useRef<HTMLParagraphElement | null>(null)
   const [isClamped, setIsClamped] = useState(false)
   const [expanded, setExpanded] = useState(false)
@@ -26,6 +32,13 @@ const GameAbout = ({ description, classnames }: GameAboutProps) => {
 
   return (
     <div className={classnames?.container}>
+      {gameName && (
+        <div className={styles.gameTitle}>
+          <h2 className={classNames('h4', styles.title, classnames?.gameTitle)}>
+            {gameName}
+          </h2>
+        </div>
+      )}
       <div className={classNames('caption', classnames?.title)}>About</div>
       <p
         ref={aboutText}


### PR DESCRIPTION
## Description

This PR is the first step to adding the game title to a location other than the carousel, as requested by @jacobc-eth. The game title was previously removed from the carousel component as asked, resulting in no game name on the game details page. Based on feedback from @pimentel08, we decided to put the game title in the About section, as it will be the future side place for that info. 

### Future desired state
![image](https://github.com/user-attachments/assets/7316c118-5698-4276-89e0-7ecfed7b8bee)

### Temporary Change
![image](https://github.com/user-attachments/assets/192827bc-2924-404c-aba4-a792dc6ff185)
