### PR TITLE
feat(LanguageSelector): add support for choosing locales options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/LanguageSelector/LanguageSelector.stories.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.stories.tsx
@@ -20,3 +20,10 @@ const props: LanguageSelectorProps = {
 export const Default: Story = {
   args: { ...props }
 }
+
+export const CustomLocales: Story = {
+  args: {
+    ...props,
+    locales: ['en', 'es', 'ko', 'ja', 'zh_Hans']
+  }
+}

--- a/src/components/LanguageSelector/constants.ts
+++ b/src/components/LanguageSelector/constants.ts
@@ -4,7 +4,29 @@ export enum FLAG_POSITION {
   APPEND = 'append'
 }
 
-export const languageLabels: { [key: string]: string } = {
+export const locales = [
+  'de',
+  'el',
+  'en',
+  'es',
+  'fr',
+  'mt',
+  'fil',
+  'it',
+  'pl',
+  'ro',
+  'ja',
+  'ko',
+  'pt_BR',
+  'ru',
+  'uk',
+  'vi',
+  'zh_Hans'
+] as const
+
+export type SupportedLocale = (typeof locales)[number]
+
+export const languageLabels: { [key in SupportedLocale]: string } = {
   de: 'Deutsch',
   el: 'Ελληνικά',
   en: 'English',
@@ -24,7 +46,7 @@ export const languageLabels: { [key: string]: string } = {
   zh_Hans: '简体中文'
 }
 
-export const languageFlags: { [key: string]: string } = {
+export const languageFlags: { [key in SupportedLocale]: string } = {
   de: '🇩🇪',
   el: '🇬🇷',
   en: '🇬🇧',

--- a/src/components/LanguageSelector/index.tsx
+++ b/src/components/LanguageSelector/index.tsx
@@ -1,11 +1,18 @@
 import React from 'react'
 
 import LanguageSelectorStyle from './LanguageSelector.module.scss'
-import { FLAG_POSITION, languageFlags, languageLabels } from './constants'
+import {
+  FLAG_POSITION,
+  SupportedLocale,
+  locales as defaultLocales,
+  languageFlags,
+  languageLabels
+} from './constants'
 
 export * from './constants'
 
 export interface LanguageSelectorProps {
+  locales?: readonly SupportedLocale[]
   flagPosition?: FLAG_POSITION
   showWeblateLink?: boolean
   i18n: {
@@ -15,6 +22,7 @@ export interface LanguageSelectorProps {
 }
 
 export function LanguageSelector({
+  locales = defaultLocales,
   flagPosition = FLAG_POSITION.PREPEND,
   i18n
 }: LanguageSelectorProps) {
@@ -24,7 +32,7 @@ export function LanguageSelector({
     i18n.changeLanguage(newLanguage)
   }
 
-  const renderOption = (lang: string) => {
+  const renderOption = (lang: SupportedLocale) => {
     const flag = languageFlags[lang]
     const label = languageLabels[lang]
 
@@ -54,7 +62,7 @@ export function LanguageSelector({
           value={currentLanguage}
           onChange={(e) => handleChangeLanguage(e.target.value)}
         >
-          {Object.keys(languageLabels).map(renderOption)}
+          {locales.map(renderOption)}
         </select>
       </div>
     </>


### PR DESCRIPTION
Right now if we want to use the selector, we need to show all the locale options. 

These changes support passing which are the locales we want to show as options.
