### PR TITLE
[Fix] Edge case where downloaded size is bigger than download size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.12.0",
+  "version": "1.12.2",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/DownloadToast/DownloadToast.stories.tsx
+++ b/src/components/DownloadToast/DownloadToast.stories.tsx
@@ -169,3 +169,29 @@ export const extraction = () => (
     />
   </div>
 )
+
+export const downloadedBiggerThanSize = () => (
+  <div
+    style={{
+      position: 'absolute',
+      right: '5%',
+      bottom: '5%',
+      width: '400px'
+    }}
+  >
+    <DownloadToast
+      imgUrl="src/assets/stories/TheWakeCover.png"
+      gameTitle="Gods Unchained"
+      downloadedInBytes={3506009664}
+      downloadSizeInBytes={2506009664}
+      estimatedCompletionTimeInMs={8600000}
+      onCancelClick={() => console.log('cancel clicked')}
+      onPauseClick={() => console.log('pause clicked')}
+      onStartClick={() => console.log('start clicked')}
+      onCloseClick={() => console.log('close clicked')}
+      onPlayClick={() => console.log('play clicked')}
+      status="inProgress"
+      statusText="Downloading"
+    />
+  </div>
+)

--- a/src/components/DownloadToast/index.tsx
+++ b/src/components/DownloadToast/index.tsx
@@ -57,6 +57,12 @@ export default function DownloadToast(props: DownloadToastType) {
     downloadSize = 0
   }
 
+  if (downloadedInBytes > downloadSize) {
+    console.error('Downloaded size is greater than download size!')
+    downloadedInBytes = downloadSize
+    percentCompleted = 100
+  }
+
   // prevent string from being too long
   let etaString = getETAStringFromMs(estCompleteTimeInMs)
   const downloadedString = size(downloadedInBytes)


### PR DESCRIPTION
This adds a safeguard to the Download Toast so it won't show a Downloaded size bigger than Total Download Size.
This happens to a few HyperPlay games while extracting.

![image](https://github.com/user-attachments/assets/eb89a6ce-a725-45e5-89a7-35f41b2aa909)
