### PR TITLE
[Tech] use ubuntu latest for pw test gha 

### DIFF
--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
our test GHA is using a runner that is already in a brown out and will be fully removed in a couple weeks

![image](https://github.com/user-attachments/assets/32892bef-b224-4f79-989e-1269b4e0fd33)

https://github.com/actions/runner-images/issues/11101