### PR TITLE
[Fix] primary button gradient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/styles/designSystem/_colors.scss
+++ b/src/styles/designSystem/_colors.scss
@@ -192,7 +192,7 @@
   --background-inverse: var(--color-neutral-50);
 
   /* Gradients */
-  --color-gradient-01: linear-gradient(180deg, var 0%, #a31ae3 100%);
+  --color-gradient-01: linear-gradient(180deg, #3c71f3 0%, #b923ff 100%);
   --color-gradient-02: linear-gradient(
     282.64deg,
     #a31ae3 9.95%,


### PR DESCRIPTION
# Summary

primary button gradient color broke on color var update. it was showing with no background color.

https://hyperplay-ui-git-feat-add-and-update-new-colors-hyperplay.vercel.app/?path=/story/button--large-primary


This reverts the color gradient 01 back to the original