### PR TITLE
[Chore] Update Sticker filledStrong colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/Sticker/index.module.scss
+++ b/src/components/Sticker/index.module.scss
@@ -184,8 +184,8 @@
     font-weight: var(--bold);
 
     &.neutral {
-      background-color: var(--color-neutral-600);
-      color: var(--color-neutral-300);
+      background-color: var(--fill-inverse-weak);
+      color: var(--color-stroke-strong);
     }
 
     &.secondary {
@@ -199,18 +199,18 @@
     }
 
     &.success {
-      background-color: var(--color-success-900);
-      color: var(--color-success-100);
+      background-color: var(--fill-success-strong);
+      color: var(--text-inverse-strong);
     }
 
     &.warning {
-      background-color: var(--color-alert-900);
-      color: var(--color-alert-400);
+      background-color: var(--fill-warning-strong);
+      color: var(--text-inverse-strong);
     }
 
     &.error {
-      background-color: var(--color-error-800);
-      color: var(--color-error-100);
+      background-color: var(--fill-error-strong);
+      color: var(--text-inverse-strong);
     }
   }
 

--- a/src/components/Sticker/index.module.scss
+++ b/src/components/Sticker/index.module.scss
@@ -180,12 +180,13 @@
 
   &.filledStrong {
     border: none;
-    border-radius: var(--corner-round, 4px);
+    border-radius: var(--corner-round, 100px);
     font-weight: var(--bold);
 
     &.neutral {
       background-color: var(--fill-inverse-weak);
-      color: var(--color-stroke-strong);
+      color: var(--text-weak);
+      border: 1px solid var(--color-stroke-strong);
     }
 
     &.secondary {
@@ -201,16 +202,19 @@
     &.success {
       background-color: var(--fill-success-strong);
       color: var(--text-inverse-strong);
+      border: none;
     }
 
     &.warning {
       background-color: var(--fill-warning-strong);
       color: var(--text-inverse-strong);
+      border: none;
     }
 
     &.error {
       background-color: var(--fill-error-strong);
       color: var(--text-inverse-strong);
+      border: none;
     }
   }
 

--- a/src/components/Sticker/index.module.scss
+++ b/src/components/Sticker/index.module.scss
@@ -181,7 +181,6 @@
   &.filledStrong {
     border: none;
     border-radius: var(--corner-round, 100px);
-    font-weight: var(--bold);
 
     &.neutral {
       background-color: var(--fill-inverse-weak);
@@ -231,7 +230,7 @@
   }
 
   &.sizeDefault {
-    padding: var(--space-3xs) var(--space-xs);
+    padding: var(--space-3xs) var(--space-sm);
     font-size: var(--text-md);
 
     .icon svg,

--- a/src/components/Sticker/index.tsx
+++ b/src/components/Sticker/index.tsx
@@ -58,7 +58,7 @@ export default function Sticker({
   return (
     <div
       {...props}
-      className={classNames(styles.sticker, className, divClasses)}
+      className={classNames('body-sm', styles.sticker, className, divClasses)}
     >
       {withIcon && <span className={styles.icon}>{withIcon}</span>}
       {withDot && (

--- a/src/styles/designSystem/_colors.scss
+++ b/src/styles/designSystem/_colors.scss
@@ -180,6 +180,7 @@
   --fill-inverse-strong: var(--color-neutral-800);
   --fill-inverse-press: var(--color-neutral-700);
   --fill-inverse-disabled: var(--color-neutral-500);
+  --fill-inverse-weak: var(--color-neutral-700);
   --fill-white: var(--color-neutral-50);
 
   /* Background */


### PR DESCRIPTION
# Summary

Update filledStrong colors and borders on `Sticker` component to match `filled` in figma but not break existing `filled` variants using `Sticker`