### PR TITLE
[Tech] refactor game info

### DIFF
--- a/src/components/BlockchainsStack/index.tsx
+++ b/src/components/BlockchainsStack/index.tsx
@@ -20,6 +20,9 @@ export interface BlockchainsStackProps
   maxVisible?: number
   showMoreCount?: boolean
   className?: string
+  // Next/Image can be passed in here to use instead of img tag
+  /* eslint-disable-next-line */
+  Image?: any
 }
 
 const BlockchainsStack = ({
@@ -28,6 +31,7 @@ const BlockchainsStack = ({
   maxVisible = 5,
   showMoreCount = true,
   className,
+  Image = 'img',
   ...props
 }: BlockchainsStackProps) => {
   const [isMoreHovered, setIsMoreHovered] = useState(false)
@@ -66,7 +70,7 @@ const BlockchainsStack = ({
       <div className={styles.blockchainIcons}>
         {visibleBlockchains.map((blockchain, index) => (
           <div key={`blockchain-${index}`} className={styles.icon}>
-            <img
+            <Image
               src={getIconSrc(blockchain.iconUrl)}
               alt={blockchain.name}
               className={styles.blockchainSvg}
@@ -101,7 +105,7 @@ const BlockchainsStack = ({
                     key={`remaining-${index}`}
                     className={styles.popoverItem}
                   >
-                    <img
+                    <Image
                       src={getIconSrc(blockchain.iconUrl)}
                       alt={blockchain.name}
                       className={styles.popoverIcons}

--- a/src/components/GameInfoV2/GameInfoV2.stories.tsx
+++ b/src/components/GameInfoV2/GameInfoV2.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import fallbackCard from '@/assets/fallback_card.jpg?url'
 
 import GameInfoV2 from '.'
+import BlockchainsStack from '../BlockchainsStack'
 import Button from '../Button'
 import styles from './GameInfoV2.module.scss'
 
@@ -51,22 +52,24 @@ export const Default: Story = {
   args: {
     ...defaultArgs,
     isLoading: false,
-    blockchains: {
-      chainId: [
-        '292',
-        '280',
-        '1789',
-        '2357',
-        '7',
-        '1',
-        '11111',
-        '1789',
-        '236',
-        '13371'
-      ],
-      maxVisible: 5,
-      showMoreCount: true
-    },
+    blockchains: (
+      <BlockchainsStack
+        chainId={[
+          '292',
+          '280',
+          '1789',
+          '2357',
+          '7',
+          '1',
+          '11111',
+          '1789',
+          '236',
+          '13371'
+        ]}
+        maxVisible={5}
+        showMoreCount={true}
+      />
+    ),
     editorChoice: {
       isEditorChoice: true,
       year: 2025
@@ -105,22 +108,24 @@ export const isLoading: Story = {
     },
     earlyAccess: true,
     playerCount: '1-4 Players',
-    blockchains: {
-      chainId: [
-        '292',
-        '280',
-        '1789',
-        '2357',
-        '7',
-        '1',
-        '11111',
-        '1789',
-        '236',
-        '13371'
-      ],
-      maxVisible: 5,
-      showMoreCount: true
-    },
+    blockchains: (
+      <BlockchainsStack
+        chainId={[
+          '292',
+          '280',
+          '1789',
+          '2357',
+          '7',
+          '1',
+          '11111',
+          '1789',
+          '236',
+          '13371'
+        ]}
+        maxVisible={5}
+        showMoreCount={true}
+      />
+    ),
     editorChoice: {
       isEditorChoice: true,
       year: 2025

--- a/src/components/GameInfoV2/GameInfoV2.stories.tsx
+++ b/src/components/GameInfoV2/GameInfoV2.stories.tsx
@@ -137,3 +137,10 @@ export const isLoading: Story = {
     )
   }
 }
+
+export const ReallyLongGameTitle: Story = {
+  args: {
+    ...defaultArgs,
+    title: 'Naruto Shippuden: Ultimate Ninja Storm 4 Road To Boruto'
+  }
+}

--- a/src/components/GameInfoV2/index.tsx
+++ b/src/components/GameInfoV2/index.tsx
@@ -60,7 +60,13 @@ const GameInfoV2: React.FC<GameInfoV2Props> = ({
   actionButton,
   isLoading,
   className,
-  i18n
+  i18n = {
+    editorChoice: "Editor's Choice",
+    version: 'Version',
+    earlyAccess: 'Early Access',
+    developer: 'Developer',
+    playerCount: 'Player Count'
+  }
 }): JSX.Element => {
   const [isImageLoading, setIsImageLoading] = useState(isLoading)
 
@@ -78,7 +84,7 @@ const GameInfoV2: React.FC<GameInfoV2Props> = ({
     editorChoiceElement = (
       <div className={classNames(styles.editorChoice, editorChoice.className)}>
         <EditorChoice />
-        {i18n?.editorChoice || "Editor's Choice"}{' '}
+        {i18n.editorChoice}
         {editorChoice.year || new Date().getFullYear()}
       </div>
     )
@@ -103,7 +109,7 @@ const GameInfoV2: React.FC<GameInfoV2Props> = ({
                 title=""
                 items={[
                   <Sticker
-                    key={i18n?.version || 'Version'}
+                    key={i18n.version}
                     styleType="neutral"
                     variant="filledStrong"
                   >
@@ -111,15 +117,15 @@ const GameInfoV2: React.FC<GameInfoV2Props> = ({
                   </Sticker>,
                   earlyAccess ? (
                     <Sticker
-                      key={i18n?.earlyAccess || 'Early Access'}
+                      key={i18n.earlyAccess}
                       styleType="neutral"
                       variant="filledStrong"
                     >
-                      {earlyAccess ? 'Early Access' : ''}
+                      {i18n.earlyAccess}
                     </Sticker>
                   ) : null,
                   <Sticker
-                    key={i18n?.developer || 'Developer'}
+                    key={i18n.developer}
                     styleType="neutral"
                     variant="filledStrong"
                   >
@@ -127,7 +133,7 @@ const GameInfoV2: React.FC<GameInfoV2Props> = ({
                   </Sticker>,
                   playerCount ? (
                     <Sticker
-                      key={i18n?.playerCount || 'Player Count'}
+                      key={i18n.playerCount}
                       styleType="neutral"
                       variant="filledStrong"
                     >
@@ -135,7 +141,6 @@ const GameInfoV2: React.FC<GameInfoV2Props> = ({
                     </Sticker>
                   ) : null
                 ]}
-                classNames={{}}
                 maxVisibleItems={8}
                 moreIndicator={<></>}
               />

--- a/src/components/GameInfoV2/index.tsx
+++ b/src/components/GameInfoV2/index.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames'
 
 import { EditorChoice } from '@/assets/images'
 
-import BlockchainsStack from '../BlockchainsStack'
 import MetaSection from '../MetaSection'
 import SocialLinks from '../SocialLinks/SocialLinks'
 import Sticker from '../Sticker'
@@ -24,11 +23,7 @@ export interface GameInfoV2Props {
   earlyAccess?: boolean
   playerCount?: string
   ImageComponent?: React.ReactNode
-  blockchains?: {
-    chainId: string[]
-    maxVisible?: number
-    showMoreCount?: boolean
-  }
+  blockchains?: React.ReactNode
   socialLinks?: {
     type: string
     url: string
@@ -145,13 +140,7 @@ const GameInfoV2: React.FC<GameInfoV2Props> = ({
                 moreIndicator={<></>}
               />
             </div>
-            {blockchains ? (
-              <BlockchainsStack
-                chainId={blockchains.chainId}
-                maxVisible={blockchains.maxVisible}
-                showMoreCount={blockchains.showMoreCount}
-              />
-            ) : null}
+            {blockchains}
           </div>
         </div>
 

--- a/src/components/MetaSection/MetaSection.stories.tsx
+++ b/src/components/MetaSection/MetaSection.stories.tsx
@@ -1,18 +1,19 @@
 import React from 'react'
+
 import { Meta, StoryObj } from '@storybook/react'
 import { expect, within } from '@storybook/test'
 import {
-  IconDeviceGamepad,
-  IconLanguage,
   IconCategory,
-  IconFlag,
+  IconDeviceGamepad,
   IconDeviceGamepad2,
-  IconX,
-  IconPlus
+  IconFlag,
+  IconLanguage,
+  IconPlus,
+  IconX
 } from '@tabler/icons-react'
 
-import Sticker from '../Sticker'
 import Button from '../Button'
+import Sticker from '../Sticker'
 import MetaSection from './index'
 
 /**

--- a/src/components/SocialLinks/SocialLinks.tsx
+++ b/src/components/SocialLinks/SocialLinks.tsx
@@ -1,4 +1,6 @@
-import React from 'react'
+import React, { HTMLAttributes } from 'react'
+
+import cn from 'classnames'
 
 import { DiscordFilled, Globe, X, Youtube } from '@/assets/images'
 
@@ -11,7 +13,7 @@ export interface SocialLink {
   className?: string
 }
 
-export interface SocialLinksProps {
+export interface SocialLinksProps extends HTMLAttributes<HTMLDivElement> {
   socialLinks: SocialLink[]
 }
 
@@ -30,9 +32,13 @@ const socialIcons = (type: string) => {
   }
 }
 
-const SocialLinks: React.FC<SocialLinksProps> = ({ socialLinks }) => {
+const SocialLinks: React.FC<SocialLinksProps> = ({
+  socialLinks,
+  className,
+  ...props
+}) => {
   return (
-    <div className={styles.socialLinks}>
+    <div className={cn(styles.socialLinks, className)} {...props}>
       {socialLinks.map((link, index) => {
         const { icon: Icon, className } = socialIcons(link.type)
         return (
@@ -42,7 +48,7 @@ const SocialLinks: React.FC<SocialLinksProps> = ({ socialLinks }) => {
             target="_blank"
             rel="noopener noreferrer"
           >
-            <Button type="secondary" size="icon" onClick={() => {}}>
+            <Button type="secondary" size="icon">
               {Icon ? <Icon className={className} /> : null}
             </Button>
           </a>


### PR DESCRIPTION
I figured it might be easier to open a PR showing some changes @biliesilva 

# AI Summary 

This pull request includes several changes to the `BlockchainsStack` and `GameInfoV2` components, as well as updates to the `SocialLinks` component and storybook files. The main goal is to improve component flexibility and code readability.

### Enhancements to `BlockchainsStack` component:
* Added an `Image` prop to allow the use of a custom image component instead of the default `img` tag.
* Updated the component to use the `Image` prop in place of the `img` tag for blockchain icons. [[1]](diffhunk://#diff-fa2aa420e4e29863c1f4e2f6c4e22ec96c63ab64b4250b8529750c6fc1814b6bL69-R73) [[2]](diffhunk://#diff-fa2aa420e4e29863c1f4e2f6c4e22ec96c63ab64b4250b8529750c6fc1814b6bL104-R108)

### Updates to `GameInfoV2` component:
* Replaced the `blockchains` prop with a `ReactNode` to allow for more flexible rendering of blockchain-related content.
* Added default values to the `i18n` prop to ensure consistent localization.
* Simplified the use of `i18n` keys within the component. [[1]](diffhunk://#diff-c2bc04283503ec05e45fffb0153f895d79a0785a0c4c0f3b96651de96674355fL81-R82) [[2]](diffhunk://#diff-c2bc04283503ec05e45fffb0153f895d79a0785a0c4c0f3b96651de96674355fL106-R143)

### Enhancements to `SocialLinks` component:
* Extended `SocialLinksProps` to include `HTMLAttributes<HTMLDivElement>` for better flexibility.
* Added `className` prop and spread remaining props to the root `div` element for enhanced customization.
* Removed unnecessary `onClick` handler from `Button` component.