### PR TITLE
[feat] Add prop for disabling amountPerUser on RewardERC20_721

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/RewardsSummary/components/FormRewards/components/RewardERC20_721/index.tsx
+++ b/src/components/RewardsSummary/components/FormRewards/components/RewardERC20_721/index.tsx
@@ -14,6 +14,7 @@ export interface RewardERC20_721Props extends TokenRewardInput {
   tokenType: 'ERC20' | 'ERC721'
   marketplaceUrlInputProps?: TextInputProps
   i18n?: FormRewardsI18n
+  hideAmountPerUser?: boolean
 }
 
 export function RewardERC20_721({
@@ -22,7 +23,8 @@ export function RewardERC20_721({
   amountPerUserInputProps,
   marketplaceUrlInputProps,
   tokenType,
-  i18n = DEFAULT_FORM_REWARDS_i18n
+  i18n = DEFAULT_FORM_REWARDS_i18n,
+  hideAmountPerUser = false
 }: RewardERC20_721Props) {
   let tokenInput = (
     <TextInput
@@ -52,7 +54,7 @@ export function RewardERC20_721({
         />
         {tokenInput}
       </div>
-      {tokenType === 'ERC20' ? (
+      {tokenType === 'ERC20' || !hideAmountPerUser ? (
         <TextInput
           label={i18n.label.amountPerUser}
           placeholder={i18n.placeholder.amountPerUser}


### PR DESCRIPTION
## Summary 

Adds a way to hide the `amountPerUser` on  `RewardERC20_721` even when the reward is an erc20 but the questType is `LEADERBOARD`.

<img width="1102" alt="image" src="https://github.com/user-attachments/assets/ce13f9bc-6991-4c61-9583-e7957faf7eb3" />
