### PR TITLE
[feat] Hide amountPerUser and totalPlayerReach for LEADERBOARD quest type

### DIFF
--- a/src/components/RewardDeposit/RewardDeposit.stories.tsx
+++ b/src/components/RewardDeposit/RewardDeposit.stories.tsx
@@ -74,9 +74,13 @@ export const ERC20PendingDeposit: Story = {
             : undefined
         }
         DepositComponent={
-          <RewardERC20Deposit
-            totalPlayerReachNumberInputProps={form.getInputProps('playerReach')}
-          />
+          args.questType === 'LEADERBOARD' ? undefined : (
+            <RewardERC20Deposit
+              totalPlayerReachNumberInputProps={form.getInputProps(
+                'playerReach'
+              )}
+            />
+          )
         }
         ActionComponent={
           <RewardDepositActions
@@ -111,12 +115,14 @@ export const ERC20Deposited: Story = {
         state="DEPOSITED"
         message={args.questType === 'LEADERBOARD' ? undefined : message}
         DepositComponent={
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span style={{ color: 'var(--color-neutral-400)' }}>
-              Total Player Reach
-            </span>
-            <span>{playerReach}</span>
-          </div>
+          args.questType === 'LEADERBOARD' ? undefined : (
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span style={{ color: 'var(--color-neutral-400)' }}>
+                Total Player Reach
+              </span>
+              <span>{playerReach}</span>
+            </div>
+          )
         }
       />
     )
@@ -438,16 +444,18 @@ export const ERC1155PendingDeposit: Story = {
           ])
         )}
         DepositComponent={
-          <RewardERC1155Deposit
-            tokenInputsProps={mockedErc1155RewardsTokens.map(
-              (token, index) => ({
-                label: `Total Player Reach: ${token.name}`,
-                ...form.getInputProps(`tokenIds.${index}.playerReach`),
-                placeholder: '0',
-                allowNegative: false
-              })
-            )}
-          />
+          args.questType === 'LEADERBOARD' ? undefined : (
+            <RewardERC1155Deposit
+              tokenInputsProps={mockedErc1155RewardsTokens.map(
+                (token, index) => ({
+                  label: `Total Player Reach: ${token.name}`,
+                  ...form.getInputProps(`tokenIds.${index}.playerReach`),
+                  placeholder: '0',
+                  allowNegative: false
+                })
+              )}
+            />
+          )
         }
         ActionComponent={
           <RewardDepositActions
@@ -483,25 +491,33 @@ export const ERC1155Deposited: Story = {
       <RewardDeposit
         {...args}
         state="DEPOSITED"
-        message={args.questType === 'LEADERBOARD' ? undefined : depositMessage}
+        message={args.questType !== 'LEADERBOARD' ? depositMessage : undefined}
         extraFields={{
           [`Amount Per Play: ${tokenOneName}`]: '1',
           [`Amount Per Play: ${tokenTwoName}`]: '1'
         }}
         DepositComponent={
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <span style={{ color: 'var(--color-neutral-400)' }}>
-                Total Player Reach ({tokenOneName})
-              </span>
-              <span>{tokenOneReach}</span>
-            </div>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <span style={{ color: 'var(--color-neutral-400)' }}>
-                Total Player Reach ({tokenTwoName})
-              </span>
-              <span>{tokenTwoReach}</span>
-            </div>
+            {args.questType !== 'LEADERBOARD' && (
+              <>
+                <div
+                  style={{ display: 'flex', justifyContent: 'space-between' }}
+                >
+                  <span style={{ color: 'var(--color-neutral-400)' }}>
+                    Total Player Reach ({tokenOneName})
+                  </span>
+                  <span>{tokenOneReach}</span>
+                </div>
+                <div
+                  style={{ display: 'flex', justifyContent: 'space-between' }}
+                >
+                  <span style={{ color: 'var(--color-neutral-400)' }}>
+                    Total Player Reach ({tokenTwoName})
+                  </span>
+                  <span>{tokenTwoReach}</span>
+                </div>
+              </>
+            )}
           </div>
         }
       />

--- a/src/components/RewardDeposit/RewardDeposit.stories.tsx
+++ b/src/components/RewardDeposit/RewardDeposit.stories.tsx
@@ -25,7 +25,15 @@ const meta: Meta<typeof RewardDeposit> = {
     tokenContractAddress: '0x216e17c29c175c043CF218a9105Aa1b6fa6dB31A',
     rewardType: 'erc20',
     tokenName: 'USDC',
-    amountPerPlayer: 10
+    amountPerPlayer: 10,
+    questType: 'PLAYSTREAK'
+  },
+  argTypes: {
+    questType: {
+      control: 'select',
+      options: ['PLAYSTREAK', 'LEADERBOARD'],
+      description: 'Type of quest'
+    }
   }
 }
 
@@ -60,7 +68,11 @@ export const ERC20PendingDeposit: Story = {
     return (
       <RewardDeposit
         {...args}
-        message={depositingAmount > 0 ? message : undefined}
+        message={
+          depositingAmount > 0 && args.questType !== 'LEADERBOARD'
+            ? message
+            : undefined
+        }
         DepositComponent={
           <RewardERC20Deposit
             totalPlayerReachNumberInputProps={form.getInputProps('playerReach')}
@@ -97,7 +109,7 @@ export const ERC20Deposited: Story = {
       <RewardDeposit
         {...args}
         state="DEPOSITED"
-        message={message}
+        message={args.questType === 'LEADERBOARD' ? undefined : message}
         DepositComponent={
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
             <span style={{ color: 'var(--color-neutral-400)' }}>
@@ -216,7 +228,11 @@ export const ERC721PendingDeposit: Story = {
         playerReach={totalPlayerReach ? totalPlayerReach.toString() : '-'}
         DepositComponent={
           <RewardERC721Deposit
-            message={totalPlayerReach > 0 ? message : undefined}
+            message={
+              totalPlayerReach > 0 && args.questType !== 'LEADERBOARD'
+                ? message
+                : undefined
+            }
             defaultTokenIdsListVisibilityState={true}
             onAddTokenTap={onAddToken}
             tokenIdsList={tokenIdsList}
@@ -254,6 +270,8 @@ export const ERC721Deposited: Story = {
   },
   render: (args) => {
     const tokenIdsList = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    const message = `A total of ${tokenIdsList.length} players will each be able to claim 1 ${args.tokenName} for successfully completing this Quest.`
+
     return (
       <RewardDeposit
         {...args}
@@ -270,9 +288,9 @@ export const ERC721Deposited: Story = {
               gap: 16
             }}
           >
-            <RewardDepositMessage
-              message={`A total of ${tokenIdsList.length} players will each be able to claim 1 ${args.tokenName} for successfully completing this Quest.`}
-            />
+            {args.questType !== 'LEADERBOARD' && (
+              <RewardDepositMessage message={message} />
+            )}
             <RewardDepositTokenList
               tokenCount={tokenIdsList.length}
               visibleByDefault={true}
@@ -465,7 +483,7 @@ export const ERC1155Deposited: Story = {
       <RewardDeposit
         {...args}
         state="DEPOSITED"
-        message={depositMessage}
+        message={args.questType === 'LEADERBOARD' ? undefined : depositMessage}
         extraFields={{
           [`Amount Per Play: ${tokenOneName}`]: '1',
           [`Amount Per Play: ${tokenTwoName}`]: '1'

--- a/src/components/RewardDeposit/RewardDeposit.stories.tsx
+++ b/src/components/RewardDeposit/RewardDeposit.stories.tsx
@@ -158,7 +158,7 @@ export const ERC721PendingDeposit: Story = {
     tokenName: 'AZUKI',
     amountPerPlayer: undefined
   },
-  render: (args: RewardDepositStoryProps, context) => {
+  render: (args: RewardDepositStoryProps) => {
     const isLeaderboard = args.questType === 'LEADERBOARD'
     const componentProps = { ...args }
     if (isLeaderboard) componentProps.amountPerPlayer = undefined
@@ -283,7 +283,7 @@ export const ERC721Deposited: Story = {
     tokenName: 'AZUKI',
     amountPerPlayer: undefined
   },
-  render: (args: RewardDepositStoryProps, context) => {
+  render: (args: RewardDepositStoryProps) => {
     const isLeaderboard = args.questType === 'LEADERBOARD'
     const componentProps = { ...args }
     componentProps.amountPerPlayer = undefined
@@ -430,7 +430,7 @@ export const ERC1155PendingDeposit: Story = {
     tokenName: mockedErc1155RewardsTokens.map((token) => token.name).join(', '),
     marketplaceUrl: 'https://opensea.io/collection/azuki'
   },
-  render: (args: RewardDepositStoryProps, context) => {
+  render: (args: RewardDepositStoryProps) => {
     const isLeaderboard = args.questType === 'LEADERBOARD'
     const componentProps = { ...args }
     if (isLeaderboard) componentProps.amountPerPlayer = undefined
@@ -490,7 +490,7 @@ export const ERC1155Deposited: Story = {
     tokenName: 'GOLD, SILVER',
     marketplaceUrl: 'https://opensea.io/collection/azuki'
   },
-  render: (args: RewardDepositStoryProps, context) => {
+  render: (args: RewardDepositStoryProps) => {
     const isLeaderboard = args.questType === 'LEADERBOARD'
     const componentProps = { ...args }
     if (isLeaderboard) componentProps.amountPerPlayer = undefined

--- a/src/components/RewardDeposit/RewardDeposit.stories.tsx
+++ b/src/components/RewardDeposit/RewardDeposit.stories.tsx
@@ -13,9 +13,13 @@ import { TokenIdRowProps } from './components/RewardERC721Deposit/components/Tok
 import RewardERC1155Deposit from './components/RewardERC1155Deposit'
 import { RewardDeposit } from './index'
 
-type Story = StoryObj<typeof RewardDeposit>
+type RewardDepositStoryProps = React.ComponentProps<typeof RewardDeposit> & {
+  questType?: 'PLAYSTREAK' | 'LEADERBOARD'
+}
 
-const meta: Meta<typeof RewardDeposit> = {
+type Story = StoryObj<typeof RewardDeposit & { questType?: string }>
+
+const meta: Meta<RewardDepositStoryProps> = {
   title: 'Quests/RewardDeposit',
   component: RewardDeposit,
   args: {
@@ -48,7 +52,7 @@ type ERC20Form = z.infer<typeof erc20Schema>
 const formatAmount = (amount: number) => amount.toLocaleString('en-US')
 
 export const ERC20PendingDeposit: Story = {
-  render: (args) => {
+  render: (args: RewardDepositStoryProps) => {
     const isLeaderboard = args.questType === 'LEADERBOARD'
     if (isLeaderboard) args.amountPerPlayer = undefined
 
@@ -100,7 +104,7 @@ export const ERC20PendingDeposit: Story = {
 }
 
 export const ERC20Deposited: Story = {
-  render: (args) => {
+  render: (args: RewardDepositStoryProps) => {
     const isLeaderboard = args.questType === 'LEADERBOARD'
     if (isLeaderboard) args.amountPerPlayer = undefined
 
@@ -154,9 +158,10 @@ export const ERC721PendingDeposit: Story = {
     tokenName: 'AZUKI',
     amountPerPlayer: undefined
   },
-  render: (args) => {
+  render: (args: RewardDepositStoryProps, context) => {
     const isLeaderboard = args.questType === 'LEADERBOARD'
-    if (isLeaderboard) args.amountPerPlayer = undefined
+    const componentProps = { ...args }
+    if (isLeaderboard) componentProps.amountPerPlayer = undefined
 
     const mockedOwnedTokenIds = new Map<number, boolean>(
       [1, 2, 3, 4, 5].map((id) => [id, true])
@@ -230,12 +235,11 @@ export const ERC721PendingDeposit: Story = {
     }))
 
     const totalPlayerReach = tokenIds.length
-
-    const message = `A total of ${totalPlayerReach} players be each able to claim 1 ${args.tokenName} for successfully completing this Quest.`
+    const message = `A total of ${totalPlayerReach} players be each able to claim 1 ${componentProps.tokenName} for successfully completing this Quest.`
 
     return (
       <RewardDeposit
-        {...args}
+        {...componentProps}
         playerReach={totalPlayerReach ? totalPlayerReach.toString() : '-'}
         DepositComponent={
           <RewardERC721Deposit
@@ -279,14 +283,17 @@ export const ERC721Deposited: Story = {
     tokenName: 'AZUKI',
     amountPerPlayer: undefined
   },
-  render: (args) => {
+  render: (args: RewardDepositStoryProps, context) => {
     const isLeaderboard = args.questType === 'LEADERBOARD'
+    const componentProps = { ...args }
+    componentProps.amountPerPlayer = undefined
+
     const tokenIdsList = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    const message = `A total of ${tokenIdsList.length} players will each be able to claim 1 ${args.tokenName} for successfully completing this Quest.`
+    const message = `A total of ${tokenIdsList.length} players will each be able to claim 1 ${componentProps.tokenName} for successfully completing this Quest.`
 
     return (
       <RewardDeposit
-        {...args}
+        {...componentProps}
         state="DEPOSITED"
         playerReach={tokenIdsList.length.toString()}
         DepositComponent={
@@ -423,9 +430,10 @@ export const ERC1155PendingDeposit: Story = {
     tokenName: mockedErc1155RewardsTokens.map((token) => token.name).join(', '),
     marketplaceUrl: 'https://opensea.io/collection/azuki'
   },
-  render: (args) => {
+  render: (args: RewardDepositStoryProps, context) => {
     const isLeaderboard = args.questType === 'LEADERBOARD'
-    if (isLeaderboard) args.amountPerPlayer = undefined
+    const componentProps = { ...args }
+    if (isLeaderboard) componentProps.amountPerPlayer = undefined
 
     const form = useForm<ERC1155Form>({
       initialValues: {
@@ -443,7 +451,7 @@ export const ERC1155PendingDeposit: Story = {
 
     return (
       <RewardDeposit
-        {...args}
+        {...componentProps}
         extraFields={Object.fromEntries(
           mockedErc1155RewardsTokens.map((token) => [
             `Amount Per Player (${token.name})`,
@@ -482,9 +490,10 @@ export const ERC1155Deposited: Story = {
     tokenName: 'GOLD, SILVER',
     marketplaceUrl: 'https://opensea.io/collection/azuki'
   },
-  render: (args) => {
+  render: (args: RewardDepositStoryProps, context) => {
     const isLeaderboard = args.questType === 'LEADERBOARD'
-    if (isLeaderboard) args.amountPerPlayer = undefined
+    const componentProps = { ...args }
+    if (isLeaderboard) componentProps.amountPerPlayer = undefined
 
     const tokenOneName = 'GOLD'
     const tokenTwoName = 'SILVER'
@@ -499,7 +508,7 @@ export const ERC1155Deposited: Story = {
 
     return (
       <RewardDeposit
-        {...args}
+        {...componentProps}
         state="DEPOSITED"
         message={!isLeaderboard ? depositMessage : undefined}
         extraFields={{

--- a/src/components/RewardDeposit/RewardDeposit.stories.tsx
+++ b/src/components/RewardDeposit/RewardDeposit.stories.tsx
@@ -49,6 +49,9 @@ const formatAmount = (amount: number) => amount.toLocaleString('en-US')
 
 export const ERC20PendingDeposit: Story = {
   render: (args) => {
+    const isLeaderboard = args.questType === 'LEADERBOARD'
+    if (isLeaderboard) args.amountPerPlayer = undefined
+
     const form = useForm<ERC20Form>({
       validate: zodResolver(erc20Schema)
     })
@@ -68,13 +71,9 @@ export const ERC20PendingDeposit: Story = {
     return (
       <RewardDeposit
         {...args}
-        message={
-          depositingAmount > 0 && args.questType !== 'LEADERBOARD'
-            ? message
-            : undefined
-        }
+        message={depositingAmount > 0 && !isLeaderboard ? message : undefined}
         DepositComponent={
-          args.questType === 'LEADERBOARD' ? undefined : (
+          isLeaderboard ? undefined : (
             <RewardERC20Deposit
               totalPlayerReachNumberInputProps={form.getInputProps(
                 'playerReach'
@@ -102,6 +101,9 @@ export const ERC20PendingDeposit: Story = {
 
 export const ERC20Deposited: Story = {
   render: (args) => {
+    const isLeaderboard = args.questType === 'LEADERBOARD'
+    if (isLeaderboard) args.amountPerPlayer = undefined
+
     const playerReach = 100
     const message = `A total of ${formatAmount(playerReach)} player${
       playerReach > 1 ? 's' : ''
@@ -113,9 +115,9 @@ export const ERC20Deposited: Story = {
       <RewardDeposit
         {...args}
         state="DEPOSITED"
-        message={args.questType === 'LEADERBOARD' ? undefined : message}
+        message={!isLeaderboard ? message : undefined}
         DepositComponent={
-          args.questType === 'LEADERBOARD' ? undefined : (
+          isLeaderboard ? undefined : (
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>
               <span style={{ color: 'var(--color-neutral-400)' }}>
                 Total Player Reach
@@ -153,6 +155,9 @@ export const ERC721PendingDeposit: Story = {
     amountPerPlayer: undefined
   },
   render: (args) => {
+    const isLeaderboard = args.questType === 'LEADERBOARD'
+    if (isLeaderboard) args.amountPerPlayer = undefined
+
     const mockedOwnedTokenIds = new Map<number, boolean>(
       [1, 2, 3, 4, 5].map((id) => [id, true])
     )
@@ -275,6 +280,7 @@ export const ERC721Deposited: Story = {
     amountPerPlayer: undefined
   },
   render: (args) => {
+    const isLeaderboard = args.questType === 'LEADERBOARD'
     const tokenIdsList = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     const message = `A total of ${tokenIdsList.length} players will each be able to claim 1 ${args.tokenName} for successfully completing this Quest.`
 
@@ -294,9 +300,7 @@ export const ERC721Deposited: Story = {
               gap: 16
             }}
           >
-            {args.questType !== 'LEADERBOARD' && (
-              <RewardDepositMessage message={message} />
-            )}
+            {!isLeaderboard && <RewardDepositMessage message={message} />}
             <RewardDepositTokenList
               tokenCount={tokenIdsList.length}
               visibleByDefault={true}
@@ -420,6 +424,9 @@ export const ERC1155PendingDeposit: Story = {
     marketplaceUrl: 'https://opensea.io/collection/azuki'
   },
   render: (args) => {
+    const isLeaderboard = args.questType === 'LEADERBOARD'
+    if (isLeaderboard) args.amountPerPlayer = undefined
+
     const form = useForm<ERC1155Form>({
       initialValues: {
         tokenIds: mockedErc1155RewardsTokens.map((token) => ({
@@ -444,7 +451,7 @@ export const ERC1155PendingDeposit: Story = {
           ])
         )}
         DepositComponent={
-          args.questType === 'LEADERBOARD' ? undefined : (
+          isLeaderboard ? undefined : (
             <RewardERC1155Deposit
               tokenInputsProps={mockedErc1155RewardsTokens.map(
                 (token, index) => ({
@@ -476,6 +483,9 @@ export const ERC1155Deposited: Story = {
     marketplaceUrl: 'https://opensea.io/collection/azuki'
   },
   render: (args) => {
+    const isLeaderboard = args.questType === 'LEADERBOARD'
+    if (isLeaderboard) args.amountPerPlayer = undefined
+
     const tokenOneName = 'GOLD'
     const tokenTwoName = 'SILVER'
 
@@ -491,14 +501,14 @@ export const ERC1155Deposited: Story = {
       <RewardDeposit
         {...args}
         state="DEPOSITED"
-        message={args.questType !== 'LEADERBOARD' ? depositMessage : undefined}
+        message={!isLeaderboard ? depositMessage : undefined}
         extraFields={{
           [`Amount Per Play: ${tokenOneName}`]: '1',
           [`Amount Per Play: ${tokenTwoName}`]: '1'
         }}
         DepositComponent={
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-            {args.questType !== 'LEADERBOARD' && (
+            {!isLeaderboard && (
               <>
                 <div
                   style={{ display: 'flex', justifyContent: 'space-between' }}

--- a/src/components/RewardsDepositedTable/index.tsx
+++ b/src/components/RewardsDepositedTable/index.tsx
@@ -60,8 +60,7 @@ export function RewardsDepositedTable({
   totalClaimables,
   marketplaceUrl,
   extraFields,
-  i18n = defaultI18n,
-  questType = 'PLAYSTREAK'
+  i18n = defaultI18n
 }: RewardsDepositedTableProps) {
   return (
     <table className={styles.root}>

--- a/src/components/RewardsDepositedTable/index.tsx
+++ b/src/components/RewardsDepositedTable/index.tsx
@@ -98,7 +98,7 @@ export function RewardsDepositedTable({
           <td>{i18n.tokenName}</td>
           <td>{tokenName}</td>
         </tr>
-        {amountPerPlayer !== undefined && questType !== 'LEADERBOARD' && (
+        {amountPerPlayer !== undefined && (
           <tr>
             <td>{i18n.amountPerPlayer}</td>
             <td>{amountPerPlayer}</td>

--- a/src/components/RewardsDepositedTable/index.tsx
+++ b/src/components/RewardsDepositedTable/index.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 
-import { QuestType, TokenType } from '@/common/types'
+import { TokenType } from '@/common/types'
 import { getTruncatedAddress } from '@/utils/addressUtils'
 import { getTruncatedUrl } from '@/utils/urlUtil'
 
@@ -32,7 +32,6 @@ export interface RewardsDepositedTableProps {
   marketplaceUrl?: string
   extraFields?: Record<string, string>
   i18n?: RewardDepositedTableI18nProp
-  questType?: QuestType
 }
 
 export const defaultI18n: RewardDepositedTableI18nProp = {

--- a/src/components/RewardsDepositedTable/index.tsx
+++ b/src/components/RewardsDepositedTable/index.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 
-import { TokenType } from '@/common/types'
+import { QuestType, TokenType } from '@/common/types'
 import { getTruncatedAddress } from '@/utils/addressUtils'
 import { getTruncatedUrl } from '@/utils/urlUtil'
 
@@ -32,6 +32,7 @@ export interface RewardsDepositedTableProps {
   marketplaceUrl?: string
   extraFields?: Record<string, string>
   i18n?: RewardDepositedTableI18nProp
+  questType?: QuestType
 }
 
 export const defaultI18n: RewardDepositedTableI18nProp = {
@@ -60,7 +61,8 @@ export function RewardsDepositedTable({
   totalClaimables,
   marketplaceUrl,
   extraFields,
-  i18n = defaultI18n
+  i18n = defaultI18n,
+  questType = 'PLAYSTREAK'
 }: RewardsDepositedTableProps) {
   return (
     <table className={styles.root}>
@@ -96,7 +98,7 @@ export function RewardsDepositedTable({
           <td>{i18n.tokenName}</td>
           <td>{tokenName}</td>
         </tr>
-        {amountPerPlayer !== undefined && (
+        {amountPerPlayer !== undefined && questType !== 'LEADERBOARD' && (
           <tr>
             <td>{i18n.amountPerPlayer}</td>
             <td>{amountPerPlayer}</td>


### PR DESCRIPTION
## Summary

Hides the `amountPerUser`, the `Total Player Reach` and the `reward deposit message` on the RewardsDeposit component for `LEADERBOARD` quests.


<img width="1501" alt="image" src="https://github.com/user-attachments/assets/fac504c6-29fe-46f0-ace9-b1cc90a8b7ec" />

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/809985f8-1586-4b0a-9815-2446bbd4c3a7" />

