### PR TITLE
Feat/add careers link to footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.26.5-alpha.w1",
+  "version": "1.26.5-alpha.3",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.26.5-alpha.3",
+  "version": "1.26.6",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.26.5",
+  "version": "1.26.5-alpha.w1",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -18,7 +18,10 @@ const props: FooterProps = {
     badges: { href: 'https://github.com/HyperPlay-Gaming/branding-resources' },
     cookiePolicy: { href: 'https://www.hyperplay.xyz/cookie-policy' },
     downloads: { href: 'https://www.hyperplay.xyz/downloads' },
-    developerAgreement: { href: 'https://www.hyperplay.xyz/downloads' }
+    developerAgreement: { href: 'https://www.hyperplay.xyz/downloads' },
+    careers: {
+      href: 'https://jobs.ashbyhq.com/windranger?departmentId=d4a6dd89-7856-4045-921b-e982d346249c'
+    }
   },
   langSelectorProps: {
     i18n: {

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -29,7 +29,8 @@ const props: FooterProps = {
     showLangSelector: true,
     showGetTheApp: true,
     showBrandLink: true,
-    showMetaMaskLink: true
+    showMetaMaskLink: true,
+    showCareersLink: true
   }
 }
 

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -35,6 +35,7 @@ export interface FooterProps extends HTMLProps<HTMLDivElement> {
     badges: LinkProps
     downloads: LinkProps
     developerAgreement?: LinkProps
+    careers?: LinkProps
   }
   flags: {
     showLangSelector: boolean
@@ -121,14 +122,12 @@ export function Footer({
               </a>
             ) : null}
             {flags.showCareersLink ? (
-              <a
+              <Link
                 className={FooterSectionStyle.footer__link}
-                href="https://jobs.ashbyhq.com/windranger?departmentId=d4a6dd89-7856-4045-921b-e982d346249c"
-                target="_blank"
-                rel="noopener noreferrer"
+                {...linkProps.careers}
               >
                 {i18n.careers}
-              </a>
+              </Link>
             ) : null}
             <Link
               className={FooterSectionStyle.footer__link}

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -26,6 +26,7 @@ export interface FooterProps extends HTMLProps<HTMLDivElement> {
     getTheApp: string
     getHyperPlayApp: string
     developerAgreement?: string
+    careers?: string
   }
   linkProps: {
     privacyPolicy: LinkProps
@@ -40,6 +41,7 @@ export interface FooterProps extends HTMLProps<HTMLDivElement> {
     showGetTheApp?: boolean
     showBrandLink?: boolean
     showMetaMaskLink?: boolean
+    showCareersLink?: boolean
   }
 }
 
@@ -61,13 +63,15 @@ export function Footer({
     badges: 'BADGES',
     getTheApp: 'Get the App',
     getHyperPlayApp: 'Get HyperPlay Apps',
-    developerAgreement: 'DEVELOPER AGREEMENT'
+    developerAgreement: 'DEVELOPER AGREEMENT',
+    careers: 'CAREERS'
   },
   flags = {
     showLangSelector: false,
     showGetTheApp: true,
     showBrandLink: true,
-    showMetaMaskLink: true
+    showMetaMaskLink: true,
+    showCareersLink: true
   },
   ...props
 }: FooterProps) {
@@ -114,6 +118,16 @@ export function Footer({
                 rel="noopener noreferrer"
               >
                 {i18n.brand}
+              </a>
+            ) : null}
+            {flags.showCareersLink ? (
+              <a
+                className={FooterSectionStyle.footer__link}
+                href="https://jobs.ashbyhq.com/windranger?departmentId=d4a6dd89-7856-4045-921b-e982d346249c"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {i18n.careers}
               </a>
             ) : null}
             <Link


### PR DESCRIPTION
Add a new link "Careers" to the footer to be used in the website: 

Closes: https://github.com/orgs/HyperPlay-Gaming/projects/16/views/8?pane=issue&itemId=105394256&issue=HyperPlay-Gaming%7Chyperplay-pm%7C281


NEEDED ON: 
https://github.com/HyperPlay-Gaming/website/pull/97

AND 
https://github.com/HyperPlay-Gaming/hyperplay-store/pull/370

PS. Both PR's above (97 and 370) need approval too.




