### PR TITLE
[Fix] Markdown description spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/MarkdownDescription/MarkdownDescription.stories.tsx
+++ b/src/components/MarkdownDescription/MarkdownDescription.stories.tsx
@@ -19,3 +19,24 @@ const props: MarkdownDescriptionProps = {
 export const Default: Story = {
   args: { ...props }
 }
+
+export const WithLists: Story = {
+  args: {
+    children: `### Let's Reach Level 200
+
+**Objective:**
+- Aim to reach level 200 on your new character.
+
+**Reward:**
+- Claim a rare gift upon reaching level 200!
+
+**Details:**
+- Embark on your journey and level up your new character.
+- Keep progressing until you reach the prestigious level 200.
+- Once you achieve this milestone, you'll be rewarded with a rare and exclusive gift to enhance your gameplay.
+
+**Good luck, adventurer!**
+
+For more details, visit [hyperplay](https://www.hyperplay.xyz).`
+  }
+}

--- a/src/components/QuestDetails/QuestDetails.stories.tsx
+++ b/src/components/QuestDetails/QuestDetails.stories.tsx
@@ -416,6 +416,29 @@ export const DescriptionCustomElement: Story = {
     )
   }
 }
+const listsDescription = `### Let's Reach Level 200
+
+**Objective:**
+- Aim to reach level 200 on your new character.
+
+**Reward:**
+- Claim a rare gift upon reaching level 200!
+
+**Details:**
+- Embark on your journey and level up your new character.
+- Keep progressing until you reach the prestigious level 200.
+- Once you achieve this milestone, you'll be rewarded with a rare and exclusive gift to enhance your gameplay.
+
+**Good luck, adventurer!**
+
+For more details, visit [hyperplay](https://www.hyperplay.xyz).`
+
+export const WithLists: Story = {
+  args: {
+    ...props,
+    description: <MarkdownDescription>{listsDescription}</MarkdownDescription>
+  }
+}
 
 export const isClaimed: Story = {
   args: {

--- a/src/components/QuestDetails/index.module.scss
+++ b/src/components/QuestDetails/index.module.scss
@@ -19,7 +19,6 @@
 }
 
 .description {
-  white-space: pre-wrap;
   text-wrap: wrap;
   line-height: var(--space-xl);
 }


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/f3ee0f0a-4242-4694-9a82-37aa3603304e)


After

![image](https://github.com/user-attachments/assets/448ef2bd-e912-4b2b-8c16-4c937ea7ce69)
