### PR TITLE
[bug][React 19] Prop destructuring fix for RewardFormCard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.30.8",
+  "version": "1.30.9",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/RewardFormCard/index.tsx
+++ b/src/components/RewardFormCard/index.tsx
@@ -20,9 +20,19 @@ export interface RewardFormCardProps extends ContainerInteractiveProps {
   tokenTypeInputProps?: SelectProps
   rewardImageProps?: RewardImageInputProps
   RewardContract?: ReactNode
+  children?: ReactNode
 }
 
-function RewardFormCard({ classNames, ...props }: RewardFormCardProps) {
+function RewardFormCard({
+  classNames,
+  networkInputProps,
+  tokenContractAddressInputProps,
+  tokenTypeInputProps,
+  rewardImageProps,
+  RewardContract,
+  children,
+  ...containerProps
+}: RewardFormCardProps) {
   return (
     <ContainerInteractive
       classNames={{
@@ -30,13 +40,13 @@ function RewardFormCard({ classNames, ...props }: RewardFormCardProps) {
         title: cn(styles.title, classNames?.title),
         root: cn(styles.root, classNames?.root)
       }}
-      {...props}
+      {...containerProps}
     >
-      <Select {...props.networkInputProps} />
-      {props.RewardContract}
+      <Select {...networkInputProps} />
+      {RewardContract}
       <div className={styles.split}>
         <div>
-          <RewardImageInput label="Reward Image" {...props.rewardImageProps} />
+          <RewardImageInput label="Reward Image" {...rewardImageProps} />
           <span className="text--sm color-neutral-400 text--semibold">
             Requirements:
           </span>
@@ -47,9 +57,9 @@ function RewardFormCard({ classNames, ...props }: RewardFormCardProps) {
           </ul>
         </div>
         <div className={styles.inputs}>
-          <TextInput {...props.tokenContractAddressInputProps} />
-          <Select {...props.tokenTypeInputProps} />
-          {props.children}
+          <TextInput {...tokenContractAddressInputProps} />
+          <Select {...tokenTypeInputProps} />
+          {children}
         </div>
       </div>
     </ContainerInteractive>


### PR DESCRIPTION

## Summary 

With React 19 have stricter in[put prop validation is causes the following Next15 build errors on the dev portal. It stems from use not properly filtering props that then get passed to native dom elements. In React18 this would just silently ignore the extra props.

<img width="1723" alt="image" src="https://github.com/user-attachments/assets/65883f4a-b945-43f2-bf2a-0369b4424cc4" />


1. **RewardFormCard** spreads `{...props}` → **ContainerInteractive**
2. **ContainerInteractive** spreads `{...props}` → **DarkContainer** 
3. **DarkContainer** spreads `{...props}` → **actual DOM `<div>` element** (line 12)

So the custom props like `networkInputProps`, `tokenContractAddressInputProps`, `tokenTypeInputProps`, `rewardImageProps`, and `RewardContract` from `RewardFormCard` were flowing all the way down to the DOM `<div>` element in `DarkContainer`, which is exactly what triggers React 19 warnings.

The issue occurs in this prop flow:

**Before the fix:**
```
RewardFormCard
  ├─ Custom props: networkInputProps, tokenContractAddressInputProps, etc.
  └─ Spreads {...props} to ContainerInteractive
      └─ Spreads {...props} to DarkContainer  
          └─ Spreads {...props} to DOM <div> ❌ React 19 warnings!
```

**After the fix:**
```
RewardFormCard
  ├─ Destructures custom props: networkInputProps, tokenContractAddressInputProps, etc.
  └─ Spreads {...containerProps} (only valid HTML props) to ContainerInteractive
      └─ Spreads {...props} to DarkContainer
          └─ Spreads {...props} to DOM <div> ✅ Only valid HTML attributes
```

Looking at the `ContainerInteractiveProps` interface, it extends `HTMLProps<HTMLDivElement>` and adds a few specific props (`title`, `tag`, `icon`, `classNames`). The `ContainerInteractive` component properly destructures its custom props and only passes the remaining valid props down.

So the issue was that `RewardFormCard`'s custom props like `networkInputProps`, `rewardImageProps`, etc. were flowing through the entire chain and ending up on the actual DOM `<div>` in `DarkContainer` at line 12:

```12:12:src/components/DarkContainer/index.tsx
<div className={classNames(className, styles.container)} {...props}>
```

The fix I implemented correctly intercepts these custom props at the `RewardFormCard` level, preventing them from reaching the DOM element. Only valid HTML div attributes will now be passed down the chain.
