### PR TITLE
[Feat] Updates to options accordion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.30.9",
+  "version": "1.30.10",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/OptionsAccordion/OptionsAccordion.stories.tsx
+++ b/src/components/OptionsAccordion/OptionsAccordion.stories.tsx
@@ -2,58 +2,65 @@ import React, { useState } from 'react'
 
 import { StoryObj } from '@storybook/react'
 
-import OptionsAccordion from '.'
+import OptionsAccordion, { OptionsType, PanelOptions } from '.'
 
 export default {
   title: 'OptionsAccordion',
   component: OptionsAccordion
 }
 
-type OptionsType = { [key: string]: boolean }
-const Genre: OptionsType = {
-  Action: false,
-  Adventure: false,
-  'Role-Playing': false,
-  Strategy: false,
-  Simulation: false,
-  Sports: false,
-  Racing: false
+const Genre: PanelOptions = {
+  Action: { selected: false },
+  Adventure: { selected: false },
+  'Role-Playing': { selected: false },
+  Strategy: { selected: false },
+  Simulation: { selected: false },
+  Sports: { selected: false },
+  Racing: { selected: false }
 }
 
-const Systems: OptionsType = {
-  Windows: false,
-  Mac: false,
-  Linux: false,
-  Browser: false
+const Systems: PanelOptions = {
+  Windows: { selected: false },
+  Mac: { selected: false },
+  Linux: { selected: false },
+  Browser: { selected: false }
 }
 
-const Version: OptionsType = {
-  Alpha: false,
-  Beta: false,
-  Stable: false
+const Version: PanelOptions = {
+  Alpha: { selected: false },
+  Beta: { selected: false },
+  Stable: { selected: false }
 }
 
-const Others: OptionsType = {
-  'Token required': false,
-  Downloaded: false,
-  'Show hidden': false,
-  'Show non-available': false
+const Others: PanelOptions = {
+  'Token required': { selected: false },
+  Downloaded: { selected: false },
+  'Show hidden': { selected: false },
+  'Show non-available': { selected: false }
 }
 
-const Scrollable: OptionsType = Object.fromEntries(
-  Array.from({ length: 25 }, (_, i) => [`Item${i + 1}`, false])
+const Chains: PanelOptions = {
+  1: { selected: false, displayName: 'Ethereum Mainnet' },
+  2: { selected: false, displayName: 'Some Other Chain' },
+  1010101: { selected: false, displayName: 'Another Chain' },
+  1231123: { selected: false }
+}
+
+const Scrollable: PanelOptions = Object.fromEntries(
+  Array.from({ length: 25 }, (_, i) => [`Item${i + 1}`, { selected: false }])
 )
 
-const defaultAllFilters: { [key: string]: OptionsType } = {
+const defaultAllFilters: OptionsType = {
   Genre,
   Systems,
   Version,
   Others,
-  Scrollable
+  Scrollable,
+  Chains
 }
 
 type Props = {
-  options?: { [key: string]: OptionsType }
+  options?: OptionsType
 }
 
 type Story = StoryObj<typeof OptionsAccordion>
@@ -66,6 +73,8 @@ export const Default: Story = {
   },
   render: ({ options = defaultAllFilters }: Props) => {
     const state = useState(options)
-    return <OptionsAccordion options={options} setOptions={state[1]} />
+    return (
+      <OptionsAccordion options={defaultAllFilters} setOptions={state[1]} />
+    )
   }
 }

--- a/src/components/OptionsAccordion/index.tsx
+++ b/src/components/OptionsAccordion/index.tsx
@@ -13,7 +13,7 @@ type OptionsType = { [key: string]: { [key: string]: boolean } }
 interface OptionsAccordionProps
   extends Omit<AccordionProps<boolean>, 'children'> {
   options: OptionsType
-  setOptions: React.Dispatch<React.SetStateAction<OptionsType>>
+  setOptions: (options: OptionsType) => void
   classNames?: Partial<
     Record<
       AccordionStylesNames | 'checkboxBody' | 'optionRow' | 'panelList',
@@ -38,10 +38,10 @@ export default function OptionsAccordion({
 
     updatedOptions[optionTitle][onlyOption] = true
 
-    setOptions((currentOptions) => ({
-      ...currentOptions,
+    setOptions({
+      ...options,
       ...updatedOptions
-    }))
+    })
   }
 
   function clearOptions(optionTitle: string) {
@@ -49,10 +49,10 @@ export default function OptionsAccordion({
     for (const opt in options[optionTitle]) {
       updatedOptions[optionTitle][opt] = false
     }
-    setOptions((currentOptions) => ({
-      ...currentOptions,
+    setOptions({
+      ...options,
       ...updatedOptions
-    }))
+    })
   }
 
   function makeAccordionItem(option: string) {
@@ -77,10 +77,10 @@ export default function OptionsAccordion({
               const updatedOption: OptionsType = {}
               updatedOption[option] = options[option]
               updatedOption[option][val] = ev.target.checked
-              setOptions((currentOptions) => ({
-                ...currentOptions,
+              setOptions({
+                ...options,
                 ...updatedOption
-              }))
+              })
             }}
             data-testid={`${val}-checkbox`}
           >

--- a/src/components/OptionsAccordion/index.tsx
+++ b/src/components/OptionsAccordion/index.tsx
@@ -9,7 +9,12 @@ import styles from './OptionsAccordion.module.scss'
 
 // first key is accordion panel title, second is each option for that panel
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-type OptionsType = { [key: string]: { [key: string]: boolean } }
+export interface Option {
+  selected: boolean
+  displayName?: string
+}
+export type PanelOptions = Record<string, Option>
+export type OptionsType = Record<string, PanelOptions>
 interface OptionsAccordionProps
   extends Omit<AccordionProps<boolean>, 'children'> {
   options: OptionsType
@@ -32,11 +37,11 @@ export default function OptionsAccordion({
     const updatedOptions: OptionsType = options
     for (const optTitle in options) {
       for (const opt in options[optTitle]) {
-        updatedOptions[optTitle][opt] = false
+        updatedOptions[optTitle][opt].selected = false
       }
     }
 
-    updatedOptions[optionTitle][onlyOption] = true
+    updatedOptions[optionTitle][onlyOption].selected = true
 
     setOptions({
       ...options,
@@ -47,7 +52,7 @@ export default function OptionsAccordion({
   function clearOptions(optionTitle: string) {
     const updatedOptions: OptionsType = options
     for (const opt in options[optionTitle]) {
-      updatedOptions[optionTitle][opt] = false
+      updatedOptions[optionTitle][opt].selected = false
     }
     setOptions({
       ...options,
@@ -72,11 +77,11 @@ export default function OptionsAccordion({
         >
           <Checkbox
             type="secondary"
-            checked={options[option][val]}
+            checked={options[option][val].selected}
             onChange={(ev) => {
               const updatedOption: OptionsType = {}
               updatedOption[option] = options[option]
-              updatedOption[option][val] = ev.target.checked
+              updatedOption[option][val].selected = ev.target.checked
               setOptions({
                 ...options,
                 ...updatedOption
@@ -90,7 +95,7 @@ export default function OptionsAccordion({
                 classNames?.checkboxBody ? classNames?.checkboxBody : 'body'
               )}
             >
-              {val}
+              {options[option][val].displayName ?? val}
             </div>
           </Checkbox>
           <Button


### PR DESCRIPTION
# Summary

- change `setOptions`
- add `displayName` to support chain id's as filter keys with chain name as the display text for filtering