### PR TITLE
[UI] left align cta component for quest details component on quests page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.30.13",
+  "version": "1.30.14",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/QuestDetails/index.module.scss
+++ b/src/components/QuestDetails/index.module.scss
@@ -51,6 +51,10 @@
   margin: 0 0 0 auto;
   width: 100%;
   justify-content: flex-end;
+
+  &.isQuestsPage {
+    justify-content: flex-start;
+  }
 }
 
 .rootContent {

--- a/src/components/QuestDetails/index.tsx
+++ b/src/components/QuestDetails/index.tsx
@@ -182,7 +182,11 @@ export default function QuestDetails({
       {eligibilityComponent}
       {rewardsComponent}
       {errorAlert}
-      <div className={styles.ctaContainer}>
+      <div
+        className={cn(styles.ctaContainer, {
+          [styles.isQuestsPage]: isQuestsPage
+        })}
+      >
         {ctaComponent ?? (
           <>
             {secondCTA}


### PR DESCRIPTION
# Summary

Since the cta components are being blocked by the support icon on the client quests page, design has decided to left align them 