### PR TITLE
[Tech] Use npm instead of pnpm for publish

### DIFF
--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -16,6 +16,6 @@ jobs:
       pkg_manager_add_dev_dep: 'pnpm add -D'
       install: 'pnpm install --frozen-lockfile'
       build: 'pnpm build'
-      publish: 'pnpm publish'
+      publish: 'npm publish'
     secrets:
       NPM_TOKEN: '${{ secrets.NPM_TOKEN }}'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# Summary

pnpm publish ignores the dist/node_modules, breaking the shipped package. let's use npm publish which is working fine with some local tests 