### PR TITLE
chore: bump version to 1.33.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
only to bump a version that was conflicting with another