### PR TITLE
[Tech] Fix quest card props type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/ui",
-  "version": "1.33.2",
+  "version": "1.33.3",
   "license": "LGPL-3.0-only",
   "scripts": {
     "dev": "vite",

--- a/src/components/CardGeneric/index.tsx
+++ b/src/components/CardGeneric/index.tsx
@@ -3,9 +3,9 @@ import { DetailedHTMLProps, ImgHTMLAttributes } from 'react'
 import {
   Card,
   CardProps,
+  createPolymorphicComponent,
   Image,
-  ImageProps,
-  PolymorphicComponentProps
+  ImageProps
 } from '@mantine/core'
 import cn from 'classnames'
 
@@ -13,8 +13,7 @@ import FallbackImage from '@/assets/fallback_achievement.svg?url'
 
 import styles from './index.module.scss'
 
-export interface CardGenericProps
-  extends PolymorphicComponentProps<'div', CardProps> {
+export interface CardGenericProps extends CardProps {
   image: string
   /**
    * Props to pass to the image component
@@ -44,64 +43,64 @@ export interface CardGenericProps
   }
 }
 
-export function CardGeneric({
-  image,
-  imageProps = {},
-  showLabel = false,
-  i18n = {
-    label: 'Label'
-  },
-  statusIcon,
-  children,
-  className,
-  genericClassNames,
-  showGradientBorderAndShadow = false,
-  ...rest
-}: CardGenericProps &
-  ImageProps &
-  Omit<React.ComponentPropsWithoutRef<'div'>, keyof CardGenericProps>) {
-  return (
-    <Card
-      className={cn(
-        {
-          gradientShadow: !showGradientBorderAndShadow,
-          gradientBorderOnHover: !showGradientBorderAndShadow
-        },
-        styles.card,
-        genericClassNames?.root,
-        className
-      )}
-      {...rest}
-      unstyled
-    >
-      <Card.Section
-        pos="relative"
+export const CardGeneric = createPolymorphicComponent<'div', CardGenericProps>(
+  ({
+    image,
+    imageProps = {},
+    showLabel = false,
+    i18n = {
+      label: 'Label'
+    },
+    statusIcon,
+    children,
+    className,
+    genericClassNames,
+    showGradientBorderAndShadow = false,
+    ...rest
+  }: CardGenericProps) => {
+    return (
+      <Card
         className={cn(
-          styles.image,
-          styles.mantineOverRide,
-          genericClassNames?.image
+          {
+            gradientShadow: !showGradientBorderAndShadow,
+            gradientBorderOnHover: !showGradientBorderAndShadow
+          },
+          styles.card,
+          genericClassNames?.root,
+          className
         )}
+        {...rest}
+        unstyled
       >
-        <Image
-          src={image}
-          fallbackSrc={FallbackImage}
-          {...imageProps}
-          className={styles.achievementImage}
-        />
-        {showLabel && (
-          <div
-            className={cn(styles.label, 'eyebrow', genericClassNames?.label)}
-          >
-            {i18n.label}
-          </div>
-        )}
-      </Card.Section>
+        <Card.Section
+          pos="relative"
+          className={cn(
+            styles.image,
+            styles.mantineOverRide,
+            genericClassNames?.image
+          )}
+        >
+          <Image
+            src={image}
+            fallbackSrc={FallbackImage}
+            {...imageProps}
+            className={styles.achievementImage}
+          />
+          {showLabel && (
+            <div
+              className={cn(styles.label, 'eyebrow', genericClassNames?.label)}
+            >
+              {i18n.label}
+            </div>
+          )}
+        </Card.Section>
 
-      {statusIcon}
+        {statusIcon}
 
-      <div className={cn(styles.cardBody, genericClassNames?.body)}>
-        {children}
-      </div>
-    </Card>
-  )
-}
+        <div className={cn(styles.cardBody, genericClassNames?.body)}>
+          {children}
+        </div>
+      </Card>
+    )
+  }
+)

--- a/src/components/CardGeneric/index.tsx
+++ b/src/components/CardGeneric/index.tsx
@@ -1,13 +1,20 @@
 import { DetailedHTMLProps, ImgHTMLAttributes } from 'react'
 
-import { Card, CardProps, Image, ImageProps } from '@mantine/core'
+import {
+  Card,
+  CardProps,
+  Image,
+  ImageProps,
+  PolymorphicComponentProps
+} from '@mantine/core'
 import cn from 'classnames'
 
 import FallbackImage from '@/assets/fallback_achievement.svg?url'
 
 import styles from './index.module.scss'
 
-export interface CardGenericProps extends CardProps {
+export interface CardGenericProps
+  extends PolymorphicComponentProps<'div', CardProps> {
   image: string
   /**
    * Props to pass to the image component

--- a/src/components/QuestCard/QuestCard.stories.tsx
+++ b/src/components/QuestCard/QuestCard.stories.tsx
@@ -4,7 +4,7 @@ import { expect } from '@storybook/test'
 import questCardV2Image from '@/assets/banners/QuestCardV2Image.png?url'
 import cupheadCard from '@/assets/steamCards/cupheadCard.jpg?url'
 
-import { QuestCard, QuestCardProps } from '.'
+import { QuestCard } from '.'
 import styles from './QuestCardStory.module.scss'
 
 const meta: Meta<typeof QuestCard> = {
@@ -17,9 +17,10 @@ const meta: Meta<typeof QuestCard> = {
 
 export default meta
 
-type Story = StoryObj<typeof QuestCard>
+type Story = StoryObj<typeof meta>
 
-const props: QuestCardProps = {
+type PropsType = React.ComponentProps<typeof QuestCard>
+const props: PropsType = {
   image: questCardV2Image,
   description:
     'Lorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
@@ -130,5 +131,15 @@ export const CardWithDivProps: Story = {
     const firstDiv = canvasElement.querySelector('.gradientShadow')
 
     expect(firstDiv).toHaveAttribute('id', args.id)
+  }
+}
+
+export const LinkCard: Story = {
+  args: {
+    ...props,
+    component: 'a',
+    classNames: {
+      root: styles.root
+    }
   }
 }

--- a/src/components/QuestCard/index.tsx
+++ b/src/components/QuestCard/index.tsx
@@ -181,11 +181,11 @@ export const QuestCard = createPolymorphicComponent<'div', QuestCardProps>(
                 </Tooltip>
               </div>
 
-              {currencyAmount && (
+              {currencyAmount ? (
                 <div className={cn(styles.amount, classNames?.currencyAmount)}>
                   {currencyAmount}
                 </div>
-              )}
+              ) : null}
             </div>
           ) : null}
         </div>

--- a/src/components/QuestCard/index.tsx
+++ b/src/components/QuestCard/index.tsx
@@ -62,59 +62,60 @@ export const QuestCard = createPolymorphicComponent<'div', QuestCardProps>(
     const { elementRef: questNameRef, showTooltip: showQuestName } =
       useShowTooltipOnOverflow()
 
-  return (
-    <CardGeneric
-      className={cn(styles.card, className)}
-      genericClassNames={{
-        body: cn(styles.body, classes),
-        image: cn(styles.image, classNames?.image),
-        root: cn(styles.root, classNames?.root),
-        label: cn(styles.questType, classNames?.questType)
-      }}
-      i18n={{
-        label: questType
-      }}
-      showLabel={Boolean(questType)}
-      {...rest}
-    >
-      <div className={cn(styles.content, classNames?.content)}>
-        <div className={cn(styles.header, classNames?.header)}>
-          {title ? (
-            <div className={cn(styles.title, 'menu-item', classNames?.title)}>
-              {title}
-            </div>
-          ) : null}
-          {gameTitle ? (
-            <div
-              className={cn(
-                styles.subtitle,
-                'caption-sm',
-                classNames?.subtitle
-              )}
-            >
-              {gameTitle}
-            </div>
-          ) : null}
-          {description ? (
-            <Tooltip
-              arrowSize={16}
-              position="bottom"
-              arrowPosition="center"
-              withArrow
-              label={description}
-              className={cn(styles.tooltip, { [styles.show]: showTooltip })}
-              events={{ hover: true, touch: true, focus: false }}
-            >
+    return (
+      <CardGeneric
+        className={cn(styles.card, className)}
+        genericClassNames={{
+          body: cn(styles.body, classes),
+          image: cn(styles.image, classNames?.image),
+          root: cn(styles.root, classNames?.root),
+          label: cn(styles.questType, classNames?.questType)
+        }}
+        i18n={{
+          label: questType
+        }}
+        showLabel={Boolean(questType)}
+        {...rest}
+      >
+        <div className={cn(styles.content, classNames?.content)}>
+          <div className={cn(styles.header, classNames?.header)}>
+            {title ? (
+              <div className={cn(styles.title, 'menu-item', classNames?.title)}>
+                {title}
+              </div>
+            ) : null}
+            {gameTitle ? (
               <div
                 className={cn(
-                  styles.description,
-                  'eyebrow',
-                  classNames?.description
+                  styles.subtitle,
+                  'caption-sm',
+                  classNames?.subtitle
                 )}
-                ref={textRef}
               >
-                {description}
+                {gameTitle}
               </div>
+            ) : null}
+            {description ? (
+              <Tooltip
+                arrowSize={16}
+                position="bottom"
+                arrowPosition="center"
+                withArrow
+                label={description}
+                className={cn(styles.tooltip, { [styles.show]: showTooltip })}
+                events={{ hover: true, touch: true, focus: false }}
+              >
+                <div
+                  className={cn(
+                    styles.description,
+                    'eyebrow',
+                    classNames?.description
+                  )}
+                  ref={textRef}
+                >
+                  {description}
+                </div>
+              </Tooltip>
             ) : null}
             {gameTitle ? (
               <div

--- a/src/components/QuestCard/index.tsx
+++ b/src/components/QuestCard/index.tsx
@@ -117,39 +117,6 @@ export const QuestCard = createPolymorphicComponent<'div', QuestCardProps>(
                 </div>
               </Tooltip>
             ) : null}
-            {gameTitle ? (
-              <div
-                className={cn(
-                  styles.subtitle,
-                  'caption-sm',
-                  classNames?.subtitle
-                )}
-              >
-                {gameTitle}
-              </div>
-            ) : null}
-            {description ? (
-              <Tooltip
-                arrowSize={16}
-                position="bottom"
-                arrowPosition="center"
-                withArrow
-                label={description}
-                className={cn(styles.tooltip, { [styles.show]: showTooltip })}
-                events={{ hover: true, touch: true, focus: false }}
-              >
-                <div
-                  className={cn(
-                    styles.description,
-                    'eyebrow',
-                    classNames?.description
-                  )}
-                  ref={textRef}
-                >
-                  {description}
-                </div>
-              </Tooltip>
-            ) : null}
             {questName ? (
               <Tooltip
                 arrowSize={16}

--- a/src/components/QuestCard/index.tsx
+++ b/src/components/QuestCard/index.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames'
 
 import { CardGeneric, CardGenericProps } from '../CardGeneric'
 import styles from './index.module.scss'
-import { Tooltip } from '@mantine/core'
+import { createPolymorphicComponent, Tooltip } from '@mantine/core'
 import { useShowTooltipOnOverflow } from '@/utils/useShowTooltipOnOverflow'
 
 export interface QuestCardProps extends CardGenericProps {
@@ -35,155 +35,159 @@ export interface QuestCardProps extends CardGenericProps {
   }
 }
 
-export function QuestCard({
-  title,
-  description,
-  questName,
-  questType,
-  gameTitle,
-  rewardImage,
-  currencyAmount,
-  currencyName,
-  classNames,
-  className,
-  selected,
-  ...rest
-}: QuestCardProps) {
-  const classes: Record<string, boolean> = {}
-  classes[styles.selected] = !!selected
-  const { elementRef: textRef, showTooltip } = useShowTooltipOnOverflow()
-  const { elementRef: currencyNameRef, showTooltip: showCurrencyNameTooltip } =
-    useShowTooltipOnOverflow()
-  const { elementRef: questNameRef, showTooltip: showQuestName } =
-    useShowTooltipOnOverflow()
+export const QuestCard = createPolymorphicComponent<'div', QuestCardProps>(
+  ({
+    title,
+    description,
+    questName,
+    questType,
+    gameTitle,
+    rewardImage,
+    currencyAmount,
+    currencyName,
+    classNames,
+    className,
+    selected,
+    ...rest
+  }: QuestCardProps) => {
+    const classes: Record<string, boolean> = {}
+    classes[styles.selected] = !!selected
+    const { elementRef: textRef, showTooltip } = useShowTooltipOnOverflow()
+    const {
+      elementRef: currencyNameRef,
+      showTooltip: showCurrencyNameTooltip
+    } = useShowTooltipOnOverflow()
+    const { elementRef: questNameRef, showTooltip: showQuestName } =
+      useShowTooltipOnOverflow()
 
-  return (
-    <CardGeneric
-      className={cn(styles.card, className)}
-      genericClassNames={{
-        body: cn(styles.body, classes),
-        image: cn(styles.image, classNames?.image),
-        root: cn(styles.root, classNames?.root),
-        label: cn(styles.questType, classNames?.questType)
-      }}
-      i18n={{
-        label: questType
-      }}
-      showLabel={Boolean(questType)}
-      {...rest}
-    >
-      <div className={cn(styles.content)}>
-        <div className={cn(styles.header)}>
-          {title ? (
-            <div className={cn(styles.title, 'menu-item', classNames?.title)}>
-              {title}
-            </div>
-          ) : null}
-          {gameTitle ? (
-            <div
-              className={cn(
-                styles.subtitle,
-                'caption-sm',
-                classNames?.subtitle
-              )}
-            >
-              {gameTitle}
-            </div>
-          ) : null}
-          {description ? (
-            <Tooltip
-              arrowSize={16}
-              position="bottom"
-              arrowPosition="center"
-              withArrow
-              label={description}
-              className={cn(styles.tooltip, { [styles.show]: showTooltip })}
-              events={{ hover: true, touch: true, focus: false }}
-            >
+    return (
+      <CardGeneric
+        className={cn(styles.card, className)}
+        genericClassNames={{
+          body: cn(styles.body, classes),
+          image: cn(styles.image, classNames?.image),
+          root: cn(styles.root, classNames?.root),
+          label: cn(styles.questType, classNames?.questType)
+        }}
+        i18n={{
+          label: questType
+        }}
+        showLabel={Boolean(questType)}
+        {...rest}
+      >
+        <div className={cn(styles.content)}>
+          <div className={cn(styles.header)}>
+            {title ? (
+              <div className={cn(styles.title, 'menu-item', classNames?.title)}>
+                {title}
+              </div>
+            ) : null}
+            {gameTitle ? (
               <div
                 className={cn(
-                  styles.description,
-                  'eyebrow',
-                  classNames?.description
-                )}
-                ref={textRef}
-              >
-                {description}
-              </div>
-            </Tooltip>
-          ) : null}
-          {questName ? (
-            <Tooltip
-              arrowSize={16}
-              position="bottom"
-              arrowPosition="center"
-              withArrow
-              label={questName}
-              className={cn(styles.tooltip, {
-                [styles.show]: showQuestName
-              })}
-              events={{ hover: true, touch: true, focus: false }}
-            >
-              <div
-                ref={questNameRef}
-                className={cn(
-                  styles.questName,
-                  'title-sm',
-                  classNames?.questName
+                  styles.subtitle,
+                  'caption-sm',
+                  classNames?.subtitle
                 )}
               >
-                {questName}
+                {gameTitle}
               </div>
-            </Tooltip>
-          ) : null}
-        </div>
-        {currencyAmount || currencyName ? (
-          <div className={cn(styles.questsDetails, classNames?.questDetails)}>
-            <div className={cn(styles.avatarWithName)}>
-              <div
-                className={cn(
-                  styles.avatarContainer,
-                  classNames?.avatarContainer
-                )}
-              >
-                <img
-                  src={rewardImage}
-                  alt={`${questName} Reward Image`}
-                  className={cn(styles.avatar, classNames?.avatar)}
-                />
-              </div>
+            ) : null}
+            {description ? (
               <Tooltip
                 arrowSize={16}
                 position="bottom"
                 arrowPosition="center"
                 withArrow
-                label={currencyName}
+                label={description}
+                className={cn(styles.tooltip, { [styles.show]: showTooltip })}
+                events={{ hover: true, touch: true, focus: false }}
+              >
+                <div
+                  className={cn(
+                    styles.description,
+                    'eyebrow',
+                    classNames?.description
+                  )}
+                  ref={textRef}
+                >
+                  {description}
+                </div>
+              </Tooltip>
+            ) : null}
+            {questName ? (
+              <Tooltip
+                arrowSize={16}
+                position="bottom"
+                arrowPosition="center"
+                withArrow
+                label={questName}
                 className={cn(styles.tooltip, {
-                  [styles.show]: showCurrencyNameTooltip
+                  [styles.show]: showQuestName
                 })}
                 events={{ hover: true, touch: true, focus: false }}
               >
                 <div
-                  ref={currencyNameRef}
+                  ref={questNameRef}
                   className={cn(
-                    styles.currencyName,
-                    'body-sm',
-                    classNames?.currencyName
+                    styles.questName,
+                    'title-sm',
+                    classNames?.questName
                   )}
                 >
-                  {currencyName}
+                  {questName}
                 </div>
               </Tooltip>
-            </div>
-
-            {currencyAmount && (
-              <div className={cn(styles.amount, classNames?.currencyAmount)}>
-                {currencyAmount}
-              </div>
-            )}
+            ) : null}
           </div>
-        ) : null}
-      </div>
-    </CardGeneric>
-  )
-}
+          {currencyAmount || currencyName ? (
+            <div className={cn(styles.questsDetails, classNames?.questDetails)}>
+              <div className={cn(styles.avatarWithName)}>
+                <div
+                  className={cn(
+                    styles.avatarContainer,
+                    classNames?.avatarContainer
+                  )}
+                >
+                  <img
+                    src={rewardImage}
+                    alt={`${questName} Reward Image`}
+                    className={cn(styles.avatar, classNames?.avatar)}
+                  />
+                </div>
+                <Tooltip
+                  arrowSize={16}
+                  position="bottom"
+                  arrowPosition="center"
+                  withArrow
+                  label={currencyName}
+                  className={cn(styles.tooltip, {
+                    [styles.show]: showCurrencyNameTooltip
+                  })}
+                  events={{ hover: true, touch: true, focus: false }}
+                >
+                  <div
+                    ref={currencyNameRef}
+                    className={cn(
+                      styles.currencyName,
+                      'body-sm',
+                      classNames?.currencyName
+                    )}
+                  >
+                    {currencyName}
+                  </div>
+                </Tooltip>
+              </div>
+
+              {currencyAmount && (
+                <div className={cn(styles.amount, classNames?.currencyAmount)}>
+                  {currencyAmount}
+                </div>
+              )}
+            </div>
+          ) : null}
+        </div>
+      </CardGeneric>
+    )
+  }
+)

--- a/src/components/QuestCard/index.tsx
+++ b/src/components/QuestCard/index.tsx
@@ -5,8 +5,7 @@ import styles from './index.module.scss'
 import { Tooltip } from '@mantine/core'
 import { useShowTooltipOnOverflow } from '@/utils/useShowTooltipOnOverflow'
 
-export interface QuestCardProps
-  extends Omit<React.ComponentPropsWithoutRef<'div'>, keyof CardGenericProps> {
+export interface QuestCardProps extends CardGenericProps {
   title?: string
   image: string
   description?: string


### PR DESCRIPTION
TS was throwing errors when passing `component = "a"` even though it worked. This uses Mantine's `createPolymorphicComponent` to make sure we have the right polymorphic types for these components that ultimately wrap the polymorphic `Card` component from Mantine.