### PR TITLE
[feat] Add markdown address highlighting

### DIFF
--- a/src/components/MarkdownDescription/MarkdownDescription.module.scss
+++ b/src/components/MarkdownDescription/MarkdownDescription.module.scss
@@ -24,8 +24,8 @@
   padding: var(--space-3xs) var(--space-2xs);
   border-radius: var(--space-2xs);
   font-weight: var(--semibold);
-  background: var(--fill-brand-weak);
-  color: var(--text-brand);
+  background: var(--color-primary-600);
+  color: var(--color-primary-100);
   font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New',
     monospace;
   font-size: var(--text-sm);
@@ -33,19 +33,19 @@
   transition: background-color 0.2s ease;
 
   &:hover {
-    background: var(--fill-hover);
+    background: var(--color-primary-700);
   }
 
   &:visited {
-    color: var(--text-brand);
+    color: var(--color-primary-100);
   }
 }
 
 .number-token {
   padding: var(--space-3xs) var(--space-2xs);
   border-radius: var(--space-2xs);
-  background: var(--fill-success-weak);
-  color: var(--text-success);
+  background: var(--color-primary-600);
+  color: var(--color-primary-100);
   font-variant-numeric: tabular-nums;
   font-weight: var(--medium);
 }

--- a/src/components/MarkdownDescription/MarkdownDescription.module.scss
+++ b/src/components/MarkdownDescription/MarkdownDescription.module.scss
@@ -1,4 +1,6 @@
 @use '../../styles/designSystem/typography' as *;
+@use '../../styles/designSystem/spacing' as *;
+@use '../../styles/designSystem/colors' as *;
 
 .root {
   @extend .body-sm;
@@ -14,6 +16,36 @@
 }
 
 .blockquote {
-  color: #fbbf24;
+  color: var(--color-alert-400);
   margin: var(--space-md) 0;
+}
+
+.eth-address {
+  padding: var(--space-3xs) var(--space-2xs);
+  border-radius: var(--space-2xs);
+  font-weight: var(--semibold);
+  background: var(--fill-brand-weak);
+  color: var(--text-brand);
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New',
+    monospace;
+  font-size: var(--text-sm);
+  text-decoration: none;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background: var(--fill-hover);
+  }
+
+  &:visited {
+    color: var(--text-brand);
+  }
+}
+
+.number-token {
+  padding: var(--space-3xs) var(--space-2xs);
+  border-radius: var(--space-2xs);
+  background: var(--fill-success-weak);
+  color: var(--text-success);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--medium);
 }

--- a/src/components/MarkdownDescription/MarkdownDescription.stories.tsx
+++ b/src/components/MarkdownDescription/MarkdownDescription.stories.tsx
@@ -58,3 +58,55 @@ export const WithBlockquotes: Story = {
 For more details, visit [hyperplay](https://www.hyperplay.xyz).`
   }
 }
+
+export const WithHighlighting: Story = {
+  args: {
+    children: `### Transaction Example
+
+**You:** send 100 eth on mainnet to 0x59faeaDA8E6eacFdb6c84E2b95cC1Dc193c88F6d
+
+**Hyp3r:** It looks like your wallet doesn't have enough ETH to cover sending 100 ETH plus gas on mainnet. Please top up your account with at least 100 ETH (plus a bit extra to cover transaction fees) and let me know when you're ready to proceed.
+
+### Quest Rewards
+
+Complete this quest to earn:
+- 50 XP points
+- 25 G7 Credits
+- 1 rare NFT
+
+**Note:** You need at least 1000 tokens to participate in this quest.`
+  }
+}
+
+export const WithCustomHighlighting: Story = {
+  args: {
+    children: `### Custom Highlighting Options
+
+This example shows custom highlighting with different settings:
+
+- ETH address: 0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6
+- Large number: 1000000
+- Decimal: 123.45
+- Small number: 5
+
+**Custom explorer:** This address links to a custom explorer instead of Etherscan.`,
+    highlightOptions: {
+      addressUrl: (addr: string) => `https://polygonscan.com/address/${addr}`,
+      linkEthAddresses: true
+    }
+  }
+}
+
+export const WithoutHighlighting: Story = {
+  args: {
+    children: `### No Auto-Highlighting
+
+This example shows the component with highlighting disabled:
+
+- ETH address: 0x59faeaDA8E6eacFdb6c84E2b95cC1Dc193c88F6d
+- Numbers: 100, 50, 25, 1, 1000
+
+All text appears as normal markdown without special highlighting.`,
+    enableHighlighting: false
+  }
+}

--- a/src/components/MarkdownDescription/MarkdownDescription.stories.tsx
+++ b/src/components/MarkdownDescription/MarkdownDescription.stories.tsx
@@ -53,6 +53,7 @@ export const WithBlockquotes: Story = {
 > 
 > Just like this one with **bold text** and [links](https://hyperplay.xyz) inside!
 
+
 **Regular text** continues here in the normal color.
 
 For more details, visit [hyperplay](https://www.hyperplay.xyz).`
@@ -61,35 +62,17 @@ For more details, visit [hyperplay](https://www.hyperplay.xyz).`
 
 export const WithHighlighting: Story = {
   args: {
-    children: `### Transaction Example
+    children: `**You:** send 100 eth on mainnet to 0x59faeaDA8E6eacFdb6c84E2b95cC1Dc193c88F6d
 
-**You:** send 100 eth on mainnet to 0x59faeaDA8E6eacFdb6c84E2b95cC1Dc193c88F6d
-
-**Hyp3r:** It looks like your wallet doesn't have enough ETH to cover sending 100 ETH plus gas on mainnet. Please top up your account with at least 100 ETH (plus a bit extra to cover transaction fees) and let me know when you're ready to proceed.
-
-### Quest Rewards
-
-Complete this quest to earn:
-- 50 XP points
-- 25 G7 Credits
-- 1 rare NFT
-
-**Note:** You need at least 1000 tokens to participate in this quest.`
+**Hyp3r:** It looks like your wallet doesn't have enough ETH to cover sending 100 ETH plus gas on mainnet. Please top up your account with at least 100 ETH (plus a bit extra to cover transaction fees) and let me know when you're ready to proceed.`
   }
 }
 
 export const WithCustomHighlighting: Story = {
   args: {
-    children: `### Custom Highlighting Options
+    children: `**Custom Explorer Test:** Click this address to go to PolygonScan: 0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6
 
-This example shows custom highlighting with different settings:
-
-- ETH address: 0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6
-- Large number: 1000000
-- Decimal: 123.45
-- Small number: 5
-
-**Custom explorer:** This address links to a custom explorer instead of Etherscan.`,
+**Numbers:** 1000000, 123.45, and 5 should also be highlighted.`,
     highlightOptions: {
       addressUrl: (addr: string) => `https://polygonscan.com/address/${addr}`,
       linkEthAddresses: true

--- a/src/components/MarkdownDescription/index.tsx
+++ b/src/components/MarkdownDescription/index.tsx
@@ -1,67 +1,112 @@
+import React, { useMemo, useCallback } from 'react'
 import Markdown, { Options } from 'react-markdown'
 
 import Button from '@/components/Button'
 
+import {
+  memoizedHighlightText,
+  renderHighlightedText,
+  type HighlighterOptions
+} from '@/utils/textHighlighter'
+
 import styles from './MarkdownDescription.module.scss'
 
-export type MarkdownDescriptionProps = Options
+export interface MarkdownDescriptionProps extends Options {
+  /**
+   * Options for highlighting ETH addresses and numbers
+   */
+  highlightOptions?: HighlighterOptions
+  /**
+   * Whether to enable auto-highlighting of addresses and numbers
+   */
+  enableHighlighting?: boolean
+}
 
 export const MarkdownDescription = ({
   children,
   allowedElements = [],
   components = {},
+  highlightOptions = {},
+  enableHighlighting = true,
   ...rest
 }: MarkdownDescriptionProps) => {
-  const markdownComponentsProp: MarkdownDescriptionProps['components'] = {
-    a: ({ href: markdownLinkHref, children, ...link }) => (
-      <a
-        target="_blank"
-        href={markdownLinkHref || ''}
-        rel="noopener noreferrer"
-        {...link}
-      >
-        <Button
-          type="link"
-          size="small"
-          spacing="xs"
-          className={styles.linkBtn}
-        >
-          {children}
-        </Button>
-      </a>
-    ),
-    blockquote: ({ children, ...props }) => (
-      <blockquote className={styles.blockquote} {...props}>
-        {children}
-      </blockquote>
-    ),
-    ...components
-  }
+  // Memoized text component for highlighting
+  const textComponent = useCallback(
+    ({ children, ...props }: any) => {
+      if (!enableHighlighting || typeof children !== 'string') {
+        return <span {...props}>{children}</span>
+      }
+
+      const highlightedText = memoizedHighlightText(children, highlightOptions)
+      const renderedText = renderHighlightedText(
+        highlightedText,
+        highlightOptions
+      )
+
+      return <span {...props}>{renderedText}</span>
+    },
+    [enableHighlighting, highlightOptions]
+  )
+
+  // Memoized components to prevent unnecessary re-renders
+  const markdownComponentsProp: MarkdownDescriptionProps['components'] =
+    useMemo(
+      () => ({
+        a: ({ href: markdownLinkHref, children, ...link }) => (
+          <a
+            target="_blank"
+            href={markdownLinkHref || ''}
+            rel="noopener noreferrer"
+            {...link}
+          >
+            <Button
+              type="link"
+              size="small"
+              spacing="xs"
+              className={styles.linkBtn}
+            >
+              {children}
+            </Button>
+          </a>
+        ),
+        blockquote: ({ children, ...props }) => (
+          <blockquote className={styles.blockquote} {...props}>
+            {children}
+          </blockquote>
+        ),
+        text: textComponent,
+        ...components
+      }),
+      [textComponent, components]
+    )
 
   const markdownAllowedElementsProp: MarkdownDescriptionProps['allowedElements'] =
-    [
-      'p',
-      'strong',
-      'b',
-      'a',
-      'i',
-      'em',
-      'ul',
-      'ol',
-      'li',
-      'blockquote',
-      'h1',
-      'h2',
-      'h3',
-      'h4',
-      'h5',
-      'h6',
-      'pre',
-      'code',
-      'hr',
-      'br',
-      ...(allowedElements || [])
-    ]
+    useMemo(
+      () => [
+        'p',
+        'strong',
+        'b',
+        'a',
+        'i',
+        'em',
+        'ul',
+        'ol',
+        'li',
+        'blockquote',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'pre',
+        'code',
+        'hr',
+        'br',
+        ...(allowedElements || [])
+      ],
+      [allowedElements]
+    )
 
   return (
     <Markdown

--- a/src/utils/textHighlighter.tsx
+++ b/src/utils/textHighlighter.tsx
@@ -140,7 +140,7 @@ const renderEthAddress = (
       target="_blank"
       rel="noopener noreferrer"
       aria-label={`Ethereum address ${item.content} (opens in new tab)`}
-      title={`View on Etherscan: ${item.content}`}
+      title={`View address: ${item.content}`}
     >
       {item.content}
     </a>
@@ -200,70 +200,7 @@ export const renderHighlightedText = (
 }
 
 /**
- * LRU cache implementation using Map (maintains insertion order)
+ * Simple memoized version using React's built-in memoization
+ * For small text snippets, direct processing is fast enough
  */
-class LRUCache<K, V> {
-  private readonly maxSize: number
-  private cache: Map<K, V>
-
-  constructor(maxSize = 100) {
-    this.maxSize = maxSize
-    this.cache = new Map()
-  }
-
-  get(key: K): V | undefined {
-    if (!this.cache.has(key)) return undefined
-
-    // Move to end (most recently used)
-    const value = this.cache.get(key)!
-    this.cache.delete(key)
-    this.cache.set(key, value)
-    return value
-  }
-
-  set(key: K, value: V): void {
-    // Remove if exists to update position
-    if (this.cache.has(key)) {
-      this.cache.delete(key)
-    }
-
-    // Remove oldest if at capacity
-    if (this.cache.size >= this.maxSize) {
-      const [firstKey] = this.cache.keys()
-      if (firstKey !== undefined) {
-        this.cache.delete(firstKey)
-      }
-    }
-
-    this.cache.set(key, value)
-  }
-}
-
-/**
- * Cache instance for memoization
- */
-const cache = new LRUCache<string, HighlightedText[]>(100)
-
-/**
- * Creates stable cache key using template literals
- */
-const createCacheKey = (text: string, options: HighlighterOptions): string =>
-  `${text}::${JSON.stringify(options)}`
-
-/**
- * Memoized version of highlightText with LRU cache
- */
-export const memoizedHighlightText = (
-  text: string,
-  options: HighlighterOptions = {}
-): HighlightedText[] => {
-  const cacheKey = createCacheKey(text, options)
-  const cached = cache.get(cacheKey)
-
-  if (cached) return cached
-
-  const result = highlightText(text, options)
-  cache.set(cacheKey, result)
-
-  return result
-}
+export const memoizedHighlightText = highlightText

--- a/src/utils/textHighlighter.tsx
+++ b/src/utils/textHighlighter.tsx
@@ -1,0 +1,269 @@
+import React from 'react'
+
+/**
+ * Utility for highlighting ETH addresses and numbers in text
+ */
+
+export interface HighlightedText {
+  readonly type: 'text' | 'eth-address' | 'number'
+  readonly content: string
+  readonly start: number
+  readonly end: number
+}
+
+export interface HighlighterOptions {
+  readonly ethAddressRegex?: RegExp
+  readonly numberRegex?: RegExp
+  readonly linkEthAddresses?: boolean
+  readonly addressUrl?: (addr: string) => string
+  readonly className?: {
+    readonly ethAddress?: string
+    readonly number?: string
+  }
+}
+
+const DEFAULT_OPTIONS = {
+  ethAddressRegex: /\b0x[a-fA-F0-9]{40}\b/g,
+  numberRegex: /\b\d+(?:\.\d+)?\b/g,
+  linkEthAddresses: true,
+  addressUrl: (addr: string) => `https://etherscan.io/address/${addr}`,
+  className: {
+    ethAddress: 'eth-address',
+    number: 'number-token'
+  }
+} as const
+
+/**
+ * Merges user options with defaults using object spread
+ */
+const mergeOptions = (
+  options: HighlighterOptions = {}
+): Required<HighlighterOptions> => ({
+  ...DEFAULT_OPTIONS,
+  ...options,
+  className: {
+    ...DEFAULT_OPTIONS.className,
+    ...options.className
+  }
+})
+
+/**
+ * Creates a combined regex pattern using template literals
+ */
+const createCombinedRegex = (opts: Required<HighlighterOptions>): RegExp =>
+  new RegExp(
+    `(${opts.ethAddressRegex.source})|(${opts.numberRegex.source})`,
+    'g'
+  )
+
+/**
+ * Processes text to identify and highlight ETH addresses and numbers
+ */
+export const highlightText = (
+  text: string,
+  options: HighlighterOptions = {}
+): HighlightedText[] => {
+  if (!text?.length) {
+    return [{ type: 'text', content: text, start: 0, end: text.length }]
+  }
+
+  const opts = mergeOptions(options)
+  const segments: HighlightedText[] = []
+
+  try {
+    const regex = createCombinedRegex(opts)
+    const matches = [...text.matchAll(regex)]
+
+    let lastIndex = 0
+
+    for (const match of matches) {
+      const matchStart = match.index!
+      const matchEnd = matchStart + match[0].length
+
+      // Add text before match (using optional chaining)
+      if (matchStart > lastIndex) {
+        segments.push({
+          type: 'text',
+          content: text.slice(lastIndex, matchStart),
+          start: lastIndex,
+          end: matchStart
+        })
+      }
+
+      // Add highlighted segment
+      segments.push({
+        type: match[1] ? 'eth-address' : 'number',
+        content: match[0],
+        start: matchStart,
+        end: matchEnd
+      })
+
+      lastIndex = matchEnd
+    }
+
+    // Add remaining text (using nullish coalescing)
+    if (lastIndex < text.length) {
+      segments.push({
+        type: 'text',
+        content: text.slice(lastIndex),
+        start: lastIndex,
+        end: text.length
+      })
+    }
+
+    return segments
+  } catch (error) {
+    console.warn('Text highlighting failed:', error)
+    return [{ type: 'text', content: text, start: 0, end: text.length }]
+  }
+}
+
+/**
+ * Renders ETH address with proper accessibility
+ */
+const renderEthAddress = (
+  item: HighlightedText,
+  opts: Required<HighlighterOptions>,
+  key: string
+): React.ReactElement => {
+  const baseProps = {
+    className: opts.className.ethAddress,
+    'data-address': item.content,
+    'data-testid': 'eth-address',
+    key
+  }
+
+  return opts.linkEthAddresses ? (
+    <a
+      {...baseProps}
+      href={opts.addressUrl(item.content)}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`Ethereum address ${item.content} (opens in new tab)`}
+      title={`View on Etherscan: ${item.content}`}
+    >
+      {item.content}
+    </a>
+  ) : (
+    <span
+      {...baseProps}
+      aria-label={`Ethereum address: ${item.content}`}
+      title={item.content}
+    >
+      {item.content}
+    </span>
+  )
+}
+
+/**
+ * Renders number token with accessibility
+ */
+const renderNumber = (
+  item: HighlightedText,
+  opts: Required<HighlighterOptions>,
+  key: string
+): React.ReactElement => (
+  <span
+    key={key}
+    className={opts.className.number}
+    data-number={item.content}
+    data-testid="number-token"
+    aria-label={`Number: ${item.content}`}
+  >
+    {item.content}
+  </span>
+)
+
+/**
+ * Converts highlighted text to JSX using functional approach
+ */
+export const renderHighlightedText = (
+  highlightedText: HighlightedText[],
+  options: HighlighterOptions = {}
+): React.ReactNode[] => {
+  const opts = mergeOptions(options)
+
+  return highlightedText.map((item, index) => {
+    const key = `${item.type}-${index}-${item.start}`
+
+    switch (item.type) {
+      case 'text':
+        return item.content
+      case 'eth-address':
+        return renderEthAddress(item, opts, key)
+      case 'number':
+        return renderNumber(item, opts, key)
+      default:
+        return item.content
+    }
+  })
+}
+
+/**
+ * LRU cache implementation using Map (maintains insertion order)
+ */
+class LRUCache<K, V> {
+  private readonly maxSize: number
+  private cache: Map<K, V>
+
+  constructor(maxSize = 100) {
+    this.maxSize = maxSize
+    this.cache = new Map()
+  }
+
+  get(key: K): V | undefined {
+    if (!this.cache.has(key)) return undefined
+
+    // Move to end (most recently used)
+    const value = this.cache.get(key)!
+    this.cache.delete(key)
+    this.cache.set(key, value)
+    return value
+  }
+
+  set(key: K, value: V): void {
+    // Remove if exists to update position
+    if (this.cache.has(key)) {
+      this.cache.delete(key)
+    }
+
+    // Remove oldest if at capacity
+    if (this.cache.size >= this.maxSize) {
+      const [firstKey] = this.cache.keys()
+      if (firstKey !== undefined) {
+        this.cache.delete(firstKey)
+      }
+    }
+
+    this.cache.set(key, value)
+  }
+}
+
+/**
+ * Cache instance for memoization
+ */
+const cache = new LRUCache<string, HighlightedText[]>(100)
+
+/**
+ * Creates stable cache key using template literals
+ */
+const createCacheKey = (text: string, options: HighlighterOptions): string =>
+  `${text}::${JSON.stringify(options)}`
+
+/**
+ * Memoized version of highlightText with LRU cache
+ */
+export const memoizedHighlightText = (
+  text: string,
+  options: HighlighterOptions = {}
+): HighlightedText[] => {
+  const cacheKey = createCacheKey(text, options)
+  const cached = cache.get(cacheKey)
+
+  if (cached) return cached
+
+  const result = highlightText(text, options)
+  cache.set(cacheKey, result)
+
+  return result
+}


### PR DESCRIPTION
## Summary

Highlights numbers and addresses in markdown parser.

<img width="719" height="439" alt="image" src="https://github.com/user-attachments/assets/c03bd609-bf2f-48b3-8894-4c9dc2bd0b74" />
